### PR TITLE
Fixed recursive import when using graphics/model_puma560

### DIFF
--- a/graphics/__init__.py
+++ b/graphics/__init__.py
@@ -5,4 +5,4 @@ from graphics.graphics_robot import GraphicalRobot, RotationalJoint, PrismaticJo
 from graphics.graphics_object2d import Object2D
 from graphics.graphics_stl import import_object_from_numpy_stl
 # from graphics.graphics_text import  # None needed as of yet
-from graphics.model_puma560 import import_puma_560  # Temp exclusion (may be moved)
+# from graphics.model_puma560 import import_puma_560  # Deprecated, file moved

--- a/roboticstoolbox/models/Puma560.py
+++ b/roboticstoolbox/models/Puma560.py
@@ -17,7 +17,7 @@
 
 # all parameters are in SI units: m, radians, kg, kg.m2, N.m, N.m.s etc.
 
-from roboticstoolbox.robot.serial_link import *
+from roboticstoolbox.robot.serial_link import SerialLink
 from roboticstoolbox.robot.Link import RevoluteDH
 from math import pi
 import numpy as np

--- a/roboticstoolbox/models/graphical_puma560.py
+++ b/roboticstoolbox/models/graphical_puma560.py
@@ -1,5 +1,5 @@
 from graphics.graphics_robot import GraphicalRobot, RotationalJoint, StaticJoint, Gripper
-from roboticstoolbox.models import Puma560
+from roboticstoolbox.models.Puma560 import Puma560
 from spatialmath import SE3
 
 
@@ -24,16 +24,16 @@ def import_puma_560(g_canvas):
 
     # Get the poses for a zero-position
     puma = Puma560()
-    poses = puma.fkine(puma.config('qz'), alltout=True)
+    poses = puma.fkine(puma.qz, alltout=True)
 
     puma560.set_joint_poses([
-        SE3(),  # 0 (Base doesn't change)
-        poses[0],  # 1
-        poses[1],  # 2
-        poses[2],  # 3
-        poses[3],  # 4
-        poses[4],  # 5
-        poses[5]   # 6
+        poses[0],
+        poses[1],
+        poses[2],
+        poses[3],
+        poses[4],
+        poses[5],
+        poses[6]
     ])
 
     return puma560

--- a/tests/manual_testing_graphics.py
+++ b/tests/manual_testing_graphics.py
@@ -14,8 +14,8 @@ Alternatively, executing this file will run the test_puma560_angle_change() func
 from time import sleep
 from numpy import array
 from spatialmath import SE3, SE2
-from roboticstoolbox import Puma560
 import graphics as gph
+from roboticstoolbox.models.graphical_puma560 import import_puma_560, Puma560
 
 
 # Create a canvas on import, to allow clearing between function calls
@@ -67,7 +67,7 @@ def test_import_stl():
     """
     This test will create a canvas with the Puma560 model loaded in.
     """
-    puma560 = gph.import_puma_560(g_canvas)
+    puma560 = import_puma_560(g_canvas)
     puma560.print_joint_poses()
 
 
@@ -142,25 +142,25 @@ def test_puma560_angle_change():
     This test loads in the Puma560 model and changes its angles over time.
     Joint angles are printed for validation.
     """
-    puma560 = gph.import_puma_560(g_canvas)
+    puma560 = import_puma_560(g_canvas)
 
     print("Prior Poses")
     puma560.print_joint_poses()
 
-    # Get the poses for a ready-position
-    puma = Puma560()
-    poses = puma.fkine(puma.config('qr'), alltout=True)
-
     sleep(2)
 
+    # Get the poses for a ready-position
+    puma = Puma560()
+    poses = puma.fkine(puma.qr, alltout=True)
+
     puma560.set_joint_poses([
-        SE3(),  # 0 (Base doesn't change)
-        poses[0],  # 1
-        poses[1],  # 2
-        poses[2],  # 3
-        poses[3],  # 4
-        poses[4],  # 5
-        poses[5]  # 6
+        poses[0],
+        poses[1],
+        poses[2],
+        poses[3],
+        poses[4],
+        poses[5],
+        poses[6]
     ])
 
     print("Final Poses")
@@ -171,7 +171,7 @@ def test_clear_scene():
     """
     This test will import the Puma560 model, then after 2 seconds, clear the canvas of all models.
     """
-    puma560 = gph.import_puma_560(g_canvas)
+    puma560 = import_puma_560(g_canvas)
     puma560.set_reference_visibility(True)
 
     sleep(2)
@@ -184,22 +184,22 @@ def test_clear_scene_with_grid_updating():
     """
     This test will import the Puma560 model, then after 2 seconds, clear the canvas of all models.
     """
-    puma560 = gph.import_puma_560(g_canvas)
-
-    # Get the poses for a ready-position
-    puma = Puma560()
-    poses = puma.fkine(puma.config('qr'), alltout=True)
+    puma560 = import_puma_560(g_canvas)
 
     sleep(2)
 
+    # Get the poses for a ready-position
+    puma = Puma560()
+    poses = puma.fkine(puma.qr, alltout=True)
+
     puma560.set_joint_poses([
-        SE3(),  # 0 (Base doesn't change)
-        poses[0],  # 1
-        poses[1],  # 2
-        poses[2],  # 3
-        poses[3],  # 4
-        poses[4],  # 5
-        poses[5]  # 6
+        poses[0],
+        poses[1],
+        poses[2],
+        poses[3],
+        poses[4],
+        poses[5],
+        poses[6]
     ])
 
     sleep(2)
@@ -341,13 +341,15 @@ def test_2d_draw_path():
         [3, 4],
         [4, 4]
     ]
-    g_canvas2.draw_path(path, colour=[1, 0, 0])
+    # g_canvas2.draw_path(path, colour=[1, 0, 0])
+    raise NotImplementedError()
 
 
 def test_2d_create_object():
     g_canvas2 = gph.GraphicsCanvas2D()
 
-    obj = gph.Object2D(SE2(), g_canvas2.scene, 'c')
+    # obj = gph.Object2D(SE2(), g_canvas2.scene, 'c')
+    raise NotImplementedError()
 
 
 if __name__ == "__main__":

--- a/tests/test_graphics.py
+++ b/tests/test_graphics.py
@@ -12,7 +12,7 @@ import graphics.common_functions as common
 import graphics.graphics_canvas as canvas
 import graphics.graphics_robot as robot
 import graphics.graphics_stl as stl
-import graphics.model_puma560 as mdl_puma
+from roboticstoolbox.models.graphical_puma560 import import_puma_560
 
 
 class TestCommonFunctions(unittest.TestCase):
@@ -759,21 +759,21 @@ class TestPuma(unittest.TestCase):
         scene = canvas.GraphicsCanvas3D(title="Test Import Puma560")
 
         # Import puma560
-        robot1 = mdl_puma.import_puma_560(scene)
+        robot1 = import_puma_560(scene)
 
         # Check all joints are added
         self.assertEqual(len(robot1.joints), 7)
 
         # For each joint, check it's in the right pose
         puma = Puma560()
-        correct_poses = puma.fkine(puma.config('qz'), alltout=True)
+        correct_poses = puma.fkine(puma.qz, alltout=True)
 
         # Initial doesn't have an SE3 in correct_poses
         self.assertEqual(common.vpython_to_se3(robot1.joints[0].get_graphic_object()), SE3())
 
         # As the base doesn't have a correct pose, need to offset the check indices
         for idx in range(len(correct_poses)):
-            self.assertEqual(common.vpython_to_se3(robot1.joints[idx+1].get_graphic_object()), correct_poses[idx])
+            self.assertEqual(common.vpython_to_se3(robot1.joints[idx].get_graphic_object()), correct_poses[idx])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When importing graphics, it would import model_puma560 which in turn used roboticstoolbox.models.Puma560
It is likely this had already been imported.
Moved model_puma560 and renamed to roboticstoolbox/models/graphical_puma560.py
Must be imported separately if to be used with graphics.