### PR TITLE
Fixing Missing End Effector Link for UR-X URDF models

### DIFF
--- a/roboticstoolbox/models/URDF/UR10.py
+++ b/roboticstoolbox/models/URDF/UR10.py
@@ -29,14 +29,15 @@ class UR10(ERobot):
 
     def __init__(self):
 
-        args = super().urdf_to_ets_args(
+        elinks, name = super().urdf_to_ets_args(
             "ur_description/urdf/ur10_joint_limited_robot.urdf.xacro"
         )
 
         super().__init__(
-                args[0],
-                name=args[1],
-                manufacturer='Universal Robotics'
+                elinks,
+                name=name,
+                manufacturer='Universal Robotics',
+                gripper_links=elinks[7]
             )
 
         self.addconfiguration(

--- a/roboticstoolbox/models/URDF/UR3.py
+++ b/roboticstoolbox/models/URDF/UR3.py
@@ -28,13 +28,14 @@ class UR3(ERobot):
     """
     def __init__(self):
 
-        args = self.urdf_to_ets_args(
+        elinks, name = self.urdf_to_ets_args(
             "ur_description/urdf/ur3_joint_limited_robot.urdf.xacro")
 
         super().__init__(
-                args[0],
-                name=args[1],
-                manufacturer='Universal Robotics'
+                elinks,
+                name=name,
+                manufacturer='Universal Robotics',
+                gripper_links=elinks[7]
             )
 
         self.addconfiguration("qz", np.array([0, 0, 0, 0, 0, 0]))

--- a/roboticstoolbox/models/URDF/UR5.py
+++ b/roboticstoolbox/models/URDF/UR5.py
@@ -29,13 +29,14 @@ class UR5(ERobot):
 
     def __init__(self):
 
-        args = super().urdf_to_ets_args(
+        elinks, name = super().urdf_to_ets_args(
             "ur_description/urdf/ur5_joint_limited_robot.urdf.xacro")
 
         super().__init__(
-                args[0],
-                name=args[1],
-                manufacturer='Universal Robotics'
+                elinks,
+                name=name,
+                manufacturer='Universal Robotics',
+                gripper_links=elinks[7]
             )
 
         self.addconfiguration("qz", np.array([0, 0, 0, 0, 0, 0]))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -166,6 +166,12 @@ class TestModels(unittest.TestCase):
         nt.assert_array_almost_equal(sol0.q, qr0, decimal=4)
         nt.assert_array_almost_equal(sol1.q, qr1, decimal=4)
 
+    def test_fkine_urdf(self):
+      for model_name in rp.models.URDF.__all__:
+        m = getattr(rp.models.URDF, model_name)
+        r = m()
+        r.fkine(r.q)
+
 if __name__ == '__main__':  # pragma nocover
     unittest.main()
     # pytest.main(['tests/test_SerialLink.py'])


### PR DESCRIPTION
Many of the manipulator robot models do not have clearly defined end-effector links. This causes a crash when calling robot.fkine(robot.q).

I have updated the UR-X models to resolve this by specifying explicitly the gripper links, and have added a unit test to cover this issue.

Please note that the unit test is still failing due to the other models not having end effector links specified, but I am not sufficiently versed in these models to determine how to fix them.