### PR TITLE
Ignore fixed joints in RNE

### DIFF
--- a/tests/test_RNE.py
+++ b/tests/test_RNE.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import numpy.testing as nt
+import numpy as np
+import roboticstoolbox as rp
+import unittest
+import spatialmath as sm
+
+class TestRNE(unittest.TestCase):
+
+    def test_ur5(self):
+        ur5 = rp.models.URDF.UR5()
+        qZero = np.zeros((6,))
+        tau = ur5.rne(qZero, qZero, qZero)
+
+        # test against KDL::ChainIdSolver_RNE with the offical ur_description package 
+        self.assertAlmostEqual(tau[0], -1.72777e-26, 3)
+        self.assertAlmostEqual(tau[1], -57.9684, 3)
+        self.assertAlmostEqual(tau[2], -14.4815, 3)
+        self.assertAlmostEqual(tau[3], -1.27931e-11, 3)
+        self.assertAlmostEqual(tau[4], 1.17427e-12, 3)
+        self.assertAlmostEqual(tau[5], 0, 3)
+
+if __name__ == '__main__':
+
+    unittest.main()


### PR DESCRIPTION
First of all, great work! I already love the robotics-toolbox for python. That is exactly what I was searching for!

Unfortunately, I discovered some issue while loading with a custom URDF model which contains many fixed joint in between the actual joints and calling the recursive Newton Euler algorithm `rne` for the `ERobot `class. 
While checking my implementation for the custom URDF model, I discovered that there **are similar problems with the UR5 robot**.
Unfortunately, the `rne` methods throws the following exception:  

```
'NoneType' object has no attribute 's'
  File "/home/.../robotics-toolbox-python/roboticstoolbox/robot/ERobot.py", line 1918, in rne
    s[j] = link.v.s
```
Code to reproduce: 
```python
import numpy as np
import roboticstoolbox as rp

ur5 = rp.models.URDF.UR5()
qZero = np.zeros((6,))
print(ur5.rne(qZero, qZero, qZero))
```
**Affected Versions**: current master branch ( 98713926988f842474d7cf42d6560d53881bbf7d)  & v0.9.1 (installed via pip)
**Python Version**:  3.6.9
 
I had the same behavior for my custom model.

Apparently, for fixed joints there is no "joint axis projection"  `s` defined. Please consider the changes of my fork. I handled these fixed joints. Due to the fixed joints there will also be more link elements in the `ERobot` class that is why I changed the for loops of the forward and the backward recursion. 
It seems that these updates solve the issue for the UR5 model. I added a unit test in which I compare the values to the results of the KDL implementation of the RNE algorithm with the official `ur_description `package.

Unfortunately,  this commit does not fix the issues with my custom model.  I don't get an exception anymore, but the torques are always zero. I will try to create a minimum falling example for this model. I guess the initialization in Line 1915 to 1921 is not properly implemented if fixed joint - link combinations shall be supported within the tree.

What is your opinion on this?

Thanks.