### PR TITLE
updating ellipse.q in robot's animated plot

### DIFF
--- a/roboticstoolbox/robot/Robot.py
+++ b/roboticstoolbox/robot/Robot.py
@@ -921,6 +921,10 @@ class Robot(DynamicsMixin, IKMixin):
 
         for qk in q:
             self.q = qk
+            if vellipse:
+                vell.q =qk
+            if fellipse:
+                fell.q =qk
             env.step(dt)
 
             if movie is not None:  # pragma nocover

--- a/roboticstoolbox/robot/Robot.py
+++ b/roboticstoolbox/robot/Robot.py
@@ -14,9 +14,9 @@ from scipy.optimize import minimize, Bounds, LinearConstraint
 from roboticstoolbox.tools.null import null
 from ansitable import ANSITable, Column
 
-# from roboticstoolbox.backends.PyPlot import PyPlot, PyPlot2
-# from roboticstoolbox.backends.PyPlot.EllipsePlot import EllipsePlot
-# from roboticstoolbox.backends.Swift import Swift
+from roboticstoolbox.backends.PyPlot import PyPlot, PyPlot2
+from roboticstoolbox.backends.PyPlot.EllipsePlot import EllipsePlot
+from roboticstoolbox.backends.Swift import Swift
 
 from roboticstoolbox.robot.Dynamics import DynamicsMixin
 from roboticstoolbox.robot.IK import IKMixin


### PR DESCRIPTION
### Reported issue
https://github.com/petercorke/robotics-toolbox-python/issues/197

### Code to reproduce
```
Code to reproduce:
import roboticstoolbox.tools.trajectory as tr
from roboticstoolbox.models.DH import *

robot = Puma560()
p0 = robot.qn
p1 = -1*robot.qn
step = 50
frame = tr.jtraj(p0, p1, step)

robot.plot(frame.y, block=False, vellipse=True, movie="ellipse_fixed.gif")
```

### before 

![ellipse_ani](https://user-images.githubusercontent.com/1910865/111037730-6ae43680-8460-11eb-8d45-782c90d5126e.gif)

### after
![fixed](https://user-images.githubusercontent.com/1910865/111037747-79cae900-8460-11eb-883e-2e1bb541f405.gif)
