### PR TITLE
Point Interbotix references to correct docs

### DIFF
--- a/roboticstoolbox/models/URDF/px100.py
+++ b/roboticstoolbox/models/URDF/px100.py
@@ -24,7 +24,7 @@ class px100(ERobot):
     - qr, vertical 'READY' configuration
 
     :reference:
-        - http://www.support.interbotix.com/html/specifications/px100.html
+        - https://docs.trossenrobotics.com/interbotix_xsarms_docs/specifications/px100.html
 
     .. codeauthor:: Jesse Haviland
     .. sectionauthor:: Peter Corke

--- a/roboticstoolbox/models/URDF/px150.py
+++ b/roboticstoolbox/models/URDF/px150.py
@@ -24,7 +24,7 @@ class px150(ERobot):
     - qr, vertical 'READY' configuration
 
     :reference:
-        - http://www.support.interbotix.com/html/specifications/px150.html
+        - https://docs.trossenrobotics.com/interbotix_xsarms_docs/specifications/px150.html
 
     .. codeauthor:: Jesse Haviland
     .. sectionauthor:: Peter Corke

--- a/roboticstoolbox/models/URDF/rx150.py
+++ b/roboticstoolbox/models/URDF/rx150.py
@@ -24,7 +24,7 @@ class rx150(ERobot):
     - qr, vertical 'READY' configuration
 
     :reference:
-        - http://www.support.interbotix.com/html/specifications/rx150.html
+        - https://docs.trossenrobotics.com/interbotix_xsarms_docs/specifications/rx150.html
 
     .. codeauthor:: Jesse Haviland
     .. sectionauthor:: Peter Corke

--- a/roboticstoolbox/models/URDF/rx200.py
+++ b/roboticstoolbox/models/URDF/rx200.py
@@ -24,7 +24,7 @@ class rx200(ERobot):
     - qr, vertical 'READY' configuration
 
     :reference:
-        - http://www.support.interbotix.com/html/specifications/rx200.html#
+        - https://docs.trossenrobotics.com/interbotix_xsarms_docs/specifications/rx200.html
 
     .. codeauthor:: Jesse Haviland
     .. sectionauthor:: Peter Corke

--- a/roboticstoolbox/models/URDF/vx300.py
+++ b/roboticstoolbox/models/URDF/vx300.py
@@ -24,7 +24,7 @@ class vx300(ERobot):
     - qr, vertical 'READY' configuration
 
     :reference:
-        - http://www.support.interbotix.com/html/specifications/vx300.html
+        - https://docs.trossenrobotics.com/interbotix_xsarms_docs/specifications/vx300.html
 
     .. codeauthor:: Jesse Haviland
     .. sectionauthor:: Peter Corke

--- a/roboticstoolbox/models/URDF/vx300s.py
+++ b/roboticstoolbox/models/URDF/vx300s.py
@@ -24,7 +24,7 @@ class vx300s(ERobot):
     - qr, vertical 'READY' configuration
 
     :reference:
-        - http://www.support.interbotix.com/html/specifications/vx3006dof.html
+        - https://docs.trossenrobotics.com/interbotix_xsarms_docs/specifications/vx300s.html
 
     .. codeauthor:: Jesse Haviland
     .. sectionauthor:: Peter Corke

--- a/roboticstoolbox/models/URDF/wx200.py
+++ b/roboticstoolbox/models/URDF/wx200.py
@@ -24,7 +24,7 @@ class wx200(ERobot):
     - qr, vertical 'READY' configuration
 
     :reference:
-        - http://www.support.interbotix.com/html/specifications/wx200.html
+        - https://docs.trossenrobotics.com/interbotix_xsarms_docs/specifications/wx200.html
 
     .. codeauthor:: Jesse Haviland
     .. sectionauthor:: Peter Corke

--- a/roboticstoolbox/models/URDF/wx250.py
+++ b/roboticstoolbox/models/URDF/wx250.py
@@ -24,7 +24,7 @@ class wx250(ERobot):
     - qr, vertical 'READY' configuration
 
     :reference:
-        - http://www.support.interbotix.com/html/specifications/wx250.html
+        - https://docs.trossenrobotics.com/interbotix_xsarms_docs/specifications/wx250.html
 
     .. codeauthor:: Jesse Haviland
     .. sectionauthor:: Peter Corke

--- a/roboticstoolbox/models/URDF/wx250s.py
+++ b/roboticstoolbox/models/URDF/wx250s.py
@@ -24,7 +24,7 @@ class wx250s(ERobot):
     - qr, vertical 'READY' configuration
 
     :reference:
-        - http://www.support.interbotix.com/html/specifications/wx2506dof.html
+        - https://docs.trossenrobotics.com/interbotix_xsarms_docs/specifications/wx250s.html
 
     .. codeauthor:: Jesse Haviland
     .. sectionauthor:: Peter Corke


### PR DESCRIPTION
Changes the Interbotix X-Series arm reference links to point to the [new documentation](https://docs.trossenrobotics.com/interbotix_xsarms_docs).