### PR TITLE
import numpy build req via pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel", "numpy>=1.17.4"]

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,6 @@
 from setuptools import setup, find_packages, Extension
 import os
-
-# fmt: off
-import pip
-pip.main(['install', 'numpy>=1.17.4'])
 import numpy
-# fmt: on
 
 here = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
Getting rid of a hack to install numpy at build time, and instead declaring this build dependency in the pyproject.toml. Needed for our WASM experiments.

/cc @wolfv @jhavl 