### PR TITLE
Fixes for BDSIM blocks in arm.py

### DIFF
--- a/roboticstoolbox/blocks/arm.py
+++ b/roboticstoolbox/blocks/arm.py
@@ -685,7 +685,7 @@ class Gravload(FunctionBlock):
         super().__init__(**blockargs)
         self.type = "gravload"
 
-        self.robot = robots
+        self.robot = robot
         self.gravity = gravity
         self.inport_names(("q",))
         self.outport_names(("$\tau$",))
@@ -744,7 +744,7 @@ class Gravload_X(FunctionBlock):
         super().__init__(**blockargs)
         self.type = "gravload-x"
 
-        self.robot = robots
+        self.robot = robot
         self.gravity = gravity
         self.inport_names(("q",))
         self.outport_names(("$\tau$",))
@@ -807,7 +807,7 @@ class Inertia(FunctionBlock):
         super().__init__(**blockargs)
         self.type = "inertia"
 
-        self.robot = robots
+        self.robot = robot
         self.inport_names(("q",))
         self.outport_names(("M",))
 

--- a/roboticstoolbox/blocks/arm.py
+++ b/roboticstoolbox/blocks/arm.py
@@ -631,7 +631,7 @@ class IDyn(FunctionBlock):
         self.outport_names(("$\tau$",))
 
     def output(self, t=None):
-        tau = self.robot.rne(self.inputs[0], self.inputs[1], self.inputs[2], gravity=gravity)
+        tau = self.robot.rne(self.inputs[0], self.inputs[1], self.inputs[2], gravity=self.gravity)
         return [tau]
 
 
@@ -1253,13 +1253,13 @@ class JTraj(SourceBlock):
         if qd0 is None:
             qd0 = np.zeros(q0.shape)
         else:
-            qd0 = getvector(qd0)
+            qd0 = base.getvector(qd0)
             if not len(qd0) == len(q0):
                 raise ValueError("qd0 has wrong size")
         if qdf is None:
             qdf = np.zeros(q0.shape)
         else:
-            qd1 = getvector(qdf)
+            qd1 = base.getvector(qdf)
             if not len(qd1) == len(q0):
                 raise ValueError("qd1 has wrong size")
 
@@ -1475,7 +1475,7 @@ class CTraj(SourceBlock):
             self.trapezoidalfunc = trapezoidal_func(self.q0, self.qf, self.T)
 
     def output(self, t=None):
-        if trapezoidal:
+        if self.trapezoidal:
             s = self.trapezoidalfunc(t)
         else:
             s = np.min(t / self.T, 1.0)


### PR DESCRIPTION
## Fixed constructors of  GRAVLOAD, FDYN and GRAVLOAD_X blocks

Errors were present when trying to initialize these bdsim blocks with robots. 
```robot``` properties were not assigned properly. 

##  Fixed functions calls and property references 

```trapezoidal``` property has to be ```self.trapezoidal```. Same goes for gravity and 
similiar goes for ```getvector``` function.