### PR TITLE
Incorrect tblend parameter name in documentation

### DIFF
--- a/roboticstoolbox/tools/trajectory.py
+++ b/roboticstoolbox/tools/trajectory.py
@@ -486,7 +486,7 @@ def trapezoidal(q0, qf, t, V=None):
         - For some values of ``V`` no solution is possible and an error is flagged.
         - The time vector, if given, is assumed to be monotonically increasing,
           and time scaling is based on the first and last element.
-        - ``tg`` has an extra attribute ``xblend`` which is the blend duration.
+        - ``tg`` has an extra attribute ``tblend`` which is the blend duration.
 
     :References:
 


### PR DESCRIPTION
Trapezoidal trajectory has an extra attribute `tblend` which is the blend duration. The documentation says `xblend` instead of `tblend` :wink: