### PR TITLE
Update of collision checking example

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -661,9 +661,9 @@ whole robots, discrete links, and objects in the world. For example a :math:`1
 just one link, of the robot by::
 
     >>> panda = rtb.models.Panda()
-    >>> obstacle = rtb.Box([1, 1, 1], SE3(1, 0, 0)) 
-    >>> iscollision = panda.collided(obstacle) # boolean
-    >>> iscollision = panda.links[0].collided(obstacle)
+    >>> obstacle = Cuboid([1, 1, 1], pose = SE3(1, 0, 0)) 
+    >>> iscollision = panda.iscollided(panda.q, obstacle) # boolean
+    >>> iscollision = panda.links[0].iscollided(obstacle)
 
 
 Additionally, we can compute the minimum Euclidean distance between whole


### PR DESCRIPTION
Hi @petercorke :wave:, this PR fixes issue #376.

The sample code snippet for collision detection listed on your github.io site generates the following errors:  

- `AttributeError: module 'roboticstoolbox' has no attribute 'Box'` 
- `TypeError: Cuboid.__init__() takes 2 positional arguments but 3 were given`
- `TypeError: Robot.collided() missing 1 required positional argument: 'shape'`
- `FutureWarning: method collided is deprecated, use iscollided instead`

I decided to fix this code snippet  as part of this pull request :sunglasses:

Regards,
Jan