### PR TITLE
fix: pin colored to <1.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pgraph-python",
     "scipy",
     "matplotlib",
+    "colored<1.5.0",
     "ansitable",
     "swift-sim>=1.0.0",
     "rtb-data",


### PR DESCRIPTION
Hi @petercorke! This PR fixes #384.

Colored 1.5.0 introduced breaking API changes, renaming functions `fg` and `attr` to `fore` and `style` respectively. This PR pins colored's version to `<1.5.0`.