### PR TITLE
Fixing RNE for URDFs robots with fixed joints

### DIFF
--- a/roboticstoolbox/robot/Robot.py
+++ b/roboticstoolbox/robot/Robot.py
@@ -1759,17 +1759,10 @@ class Robot(BaseRobot[Link], RobotKinematicsMixin):
 
                 # Adding inertia of fixed links
                 joint_idx = reference_link.jindex
-
-                # Trick to initialize empty I slots that don't have I components,
-                # leading to an error on addition
-                try:
-                    I[joint_idx] = I[joint_idx] + SpatialInertia(m=link.m,
-                                                                r=transform_matrix * link.r,
-                                                                I=link.I)
-                except AttributeError:
-                    I[joint_idx] = SpatialInertia(m=link.m,
-                                                  r=transform_matrix * link.r,
-                                                  I=link.I)
+                
+                # Adding inertia. This is the way found to circumvent a bug in the library
+                I.data[joint_idx] = I[joint_idx].A + \
+                                    (SpatialInertia(m=link.m, r=transform_matrix * link.r, I=link.I).data[0])
 
                 # Get joint subspace
                 if link.v is not None:

--- a/roboticstoolbox/robot/Robot.py
+++ b/roboticstoolbox/robot/Robot.py
@@ -1747,7 +1747,9 @@ class Robot(BaseRobot[Link], RobotKinematicsMixin):
 
                 # Find closest joint
                 reference_link = link
+                transform_matrix = SE3()
                 while reference_link is not None and reference_link.jindex is None:
+                    transform_matrix = transform_matrix * SE3(reference_link.A())
                     reference_link = reference_link.parent
 
                 # This means we are linked to the base link w/o joints inbetween
@@ -1755,9 +1757,11 @@ class Robot(BaseRobot[Link], RobotKinematicsMixin):
                 if reference_link is None or reference_link.jindex is None:
                     continue
 
-                # TODO: Stack static link inertias
+                # Adding inertia of fixed links
                 joint_idx = reference_link.jindex
-                I[joint_idx] = SpatialInertia(m=link.m, r=link.r)
+                I[joint_idx] = I[joint_idx] + SpatialInertia(m=link.m,
+                                                             r=transform_matrix * link.r,
+                                                             I=link.I)
 
                 # Get joint subspace
                 if link.v is not None:

--- a/roboticstoolbox/robot/Robot.py
+++ b/roboticstoolbox/robot/Robot.py
@@ -1784,7 +1784,10 @@ class Robot(BaseRobot[Link], RobotKinematicsMixin):
                 vJ = SpatialVelocity(s[j] * qdk[j])
 
                 # transform from parent(j) to j
-                Xup[j] = SE3(self.links[j].A(qk[j])).inv()
+                if self.links[j].jindex is not None:
+                    Xup[j] = SE3(self.links[j].A(qk[self.links[j].jindex])).inv()
+                else:
+                    Xup[j] = SE3(self.links[j].A()).inv()
 
                 if self.links[j].parent is None:
                     v[j] = vJ

--- a/tests/test_ERobot.py
+++ b/tests/test_ERobot.py
@@ -154,7 +154,7 @@ class TestERobot(unittest.TestCase):
         nt.assert_array_almost_equal(tau, np.r_[d11 + d12, d21 + d22])
 
     def test_URDF_inertia(self):
-        robot = rtb.models.URDF.Panda()
+        robot = rtb.models.URDF.UR10()
         try:
             robot.inertia(robot.q)
         except TypeError:

--- a/tests/test_ERobot.py
+++ b/tests/test_ERobot.py
@@ -152,6 +152,13 @@ class TestERobot(unittest.TestCase):
         tau = robot.rne(q, z, np.array([1, 1]))
         nt.assert_array_almost_equal(tau, np.r_[d11 + d12, d21 + d22])
 
+    def test_URDF_inertia(self):
+        robot = rtb.models.URDF.UR10()
+        try:
+            robot.inertia(robot.q)
+        except TypeError:
+            self.fail("inertia() with a robot containing fixed links raised an error")
+
 
 class TestERobot2(unittest.TestCase):
     def test_plot(self):

--- a/tests/test_ERobot.py
+++ b/tests/test_ERobot.py
@@ -16,8 +16,9 @@ import spatialgeometry as gm
 from math import pi, sin, cos
 
 try:
-    from sympy import symbols
-
+    from sympy import symbols, simplify
+    from sympy import sin as ssin
+    from sympy import cos as scos
     _sympy = True
 except ModuleNotFoundError:
     _sympy = False
@@ -210,19 +211,33 @@ class TestERobot2(unittest.TestCase):
         link2 = Link(ET.tx(a1) * ET.Ry(flip=True), m=m2, r=[r2, 0, 0], name="link1")
         robot = ERobot([link1, link2])
 
+        # Define symbols
         q = symbols("q:2")
         qd = symbols("qd:2")
         qdd = symbols("qdd:2")
+        q0, q1 = q
+        qd0, qd1 = qd
+        qdd0, qdd1 = qdd
+
         Q = robot.rne(q, qd, qdd, gravity=[0, 0, g], symbolic=True)
 
-        self.assertEqual(
-            str(Q[0]),
-            "a1**2*m2*qd0**2*sin(q1)*cos(q1) + a1*qd0*(-a1*m2*qd0*cos(q1) - m2*r2*(qd0 + qd1))*sin(q1) - a1*(m2*(a1*qd0*qd1*cos(q1) - a1*qdd0*sin(q1) - g*sin(q0)*cos(q1) - g*sin(q1)*cos(q0)) + (qd0 + qd1)*(-a1*m2*qd0*cos(q1) - m2*r2*(qd0 + qd1)))*sin(q1) - a1*(-a1*m2*qd0*(-qd0 - qd1)*sin(q1) - m2*r2*(qdd0 + qdd1) + m2*(-a1*qd0*qd1*sin(q1) - a1*qdd0*cos(q1) + g*sin(q0)*sin(q1) - g*cos(q0)*cos(q1)))*cos(q1) + g*m1*r1*cos(q0) + m1*qdd0*r1**2 + m2*r2**2*(qdd0 + qdd1) - m2*r2*(-a1*qd0*qd1*sin(q1) - a1*qdd0*cos(q1) + g*sin(q0)*sin(q1) - g*cos(q0)*cos(q1))",
-        )
-        self.assertEqual(
-            str(Q[1]),
-            "a1**2*m2*qd0**2*sin(q1)*cos(q1) + a1*qd0*(-a1*m2*qd0*cos(q1) - m2*r2*(qd0 + qd1))*sin(q1) + m2*r2**2*(qdd0 + qdd1) - m2*r2*(-a1*qd0*qd1*sin(q1) - a1*qdd0*cos(q1) + g*sin(q0)*sin(q1) - g*cos(q0)*cos(q1))",
-        )
+        solution_0 = a1**2*m2*qd0**2*ssin(q1)*scos(q1) + a1*qd0*(-a1*m2*qd0*scos(q1) - \
+                     m2*r2*(qd0 + qd1))*ssin(q1) - a1*(m2*(a1*qd0*qd1*scos(q1) - \
+                     a1*qdd0*ssin(q1) - g*ssin(q0)*scos(q1) - g*ssin(q1)*scos(q0)) + \
+                     (qd0 + qd1)*(-a1*m2*qd0*scos(q1) - m2*r2*(qd0 + qd1)))*ssin(q1) - \
+                     a1*(-a1*m2*qd0*(-qd0 - qd1)*ssin(q1) - m2*r2*(qdd0 + qdd1) + \
+                     m2*(-a1*qd0*qd1*ssin(q1) - a1*qdd0*scos(q1) + g*ssin(q0)*ssin(q1) - \
+                     g*scos(q0)*scos(q1)))*scos(q1) + g*m1*r1*scos(q0) + m1*qdd0*r1**2 + \
+                     m2*r2**2*(qdd0 + qdd1) - m2*r2*(-a1*qd0*qd1*ssin(q1) - \
+                     a1*qdd0*scos(q1) + g*ssin(q0)*ssin(q1) - g*scos(q0)*scos(q1))
+
+        solution_1 = a1**2*m2*qd0**2*ssin(q1)*scos(q1) + a1*qd0*(-a1*m2*qd0*scos(q1) - \
+                     m2*r2*(qd0 + qd1))*ssin(q1) + m2*r2**2*(qdd0 + qdd1) - \
+                     m2*r2*(-a1*qd0*qd1*ssin(q1) - a1*qdd0*scos(q1) + g*ssin(q0)*ssin(q1) - \
+                     g*scos(q0)*scos(q1))
+
+        self.assertEqual(simplify(Q[0]-solution_0), 0)
+        self.assertEqual(simplify(Q[1]-solution_1), 0)
 
 
 if __name__ == "__main__":  # pragma nocover

--- a/tests/test_ERobot.py
+++ b/tests/test_ERobot.py
@@ -153,7 +153,7 @@ class TestERobot(unittest.TestCase):
         nt.assert_array_almost_equal(tau, np.r_[d11 + d12, d21 + d22])
 
     def test_URDF_inertia(self):
-        robot = rtb.models.URDF.UR10()
+        robot = rtb.models.URDF.Panda()
         try:
             robot.inertia(robot.q)
         except TypeError:

--- a/tests/test_Ticker.py
+++ b/tests/test_Ticker.py
@@ -5,12 +5,15 @@
 
 from roboticstoolbox.tools.Ticker import Ticker
 import unittest
+import platform
 
 
 class TestTicker(unittest.TestCase):
 
     def test_ticker(self):
-        self.skipTest('Not working on windows or mac')
+
+        if platform.system() in ['Windows', 'Darwin']:
+            self.skipTest('Not working on windows or mac')
 
         t = Ticker(0.1)
 


### PR DESCRIPTION
This PR should fix the RNE function allowing correct execution for robot having fixed joints. It should also improve RNE computations by actually taking into account the links inertia when specified. 

This should fix the bug described in issue #368 

Unit tests were added and expended appropriately but I would still appreciate a review from someone familiar with the code.