### PR TITLE
fix: remove unused imports on EKF.py

### DIFF
--- a/roboticstoolbox/mobile/EKF.py
+++ b/roboticstoolbox/mobile/EKF.py
@@ -5,14 +5,11 @@ Python EKF Planner
 """
 from collections import namedtuple
 import numpy as np
-from math import pi
-from scipy import integrate, randn
-from scipy.linalg import sqrtm, block_diag
+from scipy.linalg import block_diag
 from scipy.stats.distributions import chi2
 import matplotlib.pyplot as plt
 from matplotlib import animation
 
-from spatialmath.base.animate import Animate
 from spatialmath import base, SE2
 from roboticstoolbox.mobile import VehicleBase
 from roboticstoolbox.mobile.landmarkmap import LandmarkMap


### PR DESCRIPTION
- Close #412

Indeed, in the latest `scipy` release ([1.12.0](https://docs.scipy.org/doc/scipy/release/1.12.0-notes.html)), they removed the, already deprecated, `scipy.randn` function. (The deprecated warning said they would remove at 2.0.0, but well...).

In `robotics-toolbox-python` there was one place where `from scipy import randn` was called: the `roboticstoolbox/mobile/EKF.py` but it was not used. Instead of limiting `scipy<1.12.0`, I removed the unused dependency (and a few others in the same file).