### PR TITLE
Update Import Statements for Random Module Compatibility

### DIFF
--- a/roboticstoolbox/mobile/EKF.py
+++ b/roboticstoolbox/mobile/EKF.py
@@ -6,7 +6,8 @@ Python EKF Planner
 from collections import namedtuple
 import numpy as np
 from math import pi
-from scipy import integrate, randn
+from scipy import integrate
+from numpy import random
 from scipy.linalg import sqrtm, block_diag
 from scipy.stats.distributions import chi2
 import matplotlib.pyplot as plt


### PR DESCRIPTION
This pull request addresses a compatibility issue with the scipy library's import statements. Previously, the code attempted to import randn directly from scipy, which is incorrect as scipy does not provide a direct import for random functionalities anymore.

**Changes Made:**

Removed `randn` from the from `scipy` import integrate, `randn` import line.
Added from `numpy` import random to use NumPy for random number generation functionalities.
These changes ensure that the code utilizes the correct library for random number generation and maintains compatibility with the latest versions of `scipy` and `numpy`.

**Benefits:**

1. Ensures the codebase is up-to-date with current library versions.
2. Prevents runtime errors due to incorrect imports.

Please review the changes and merge them if they meet the project standards. Thank you for considering this update.