### PR TITLE
Fixing and adding support for non straight joint axis in the URDF parser

### DIFF
--- a/roboticstoolbox/tools/urdf/urdf.py
+++ b/roboticstoolbox/tools/urdf/urdf.py
@@ -12,7 +12,14 @@ import copy
 import os
 import xml.etree.ElementTree as ETT
 from spatialmath import SE3, SO3
-from spatialmath.base import ArrayLike3, getvector, unitvec, unitvec_norm, angvec2r, tr2rpy
+from spatialmath.base import (
+    ArrayLike3,
+    getvector,
+    unitvec,
+    unitvec_norm,
+    angvec2r,
+    tr2rpy,
+)
 
 from io import BytesIO
 from roboticstoolbox.tools.data import rtb_path_to_datafile
@@ -23,6 +30,7 @@ from .utils import parse_origin, configure_origin
 
 # Global variable for the base path of the robot meshes
 _base_path = None
+
 
 def rotation_fromVec_toVec(
     from_this_vector: ArrayLike3, to_this_vector: ArrayLike3
@@ -70,6 +78,7 @@ def rotation_fromVec_toVec(
 
     rotation_from_to = SO3.AngVec(rotation_angle, rotation_plane)
     return rotation_from_to
+
 
 def _find_standard_joint(joint: "Joint") -> "rtb.ET | None":
     """
@@ -122,6 +131,7 @@ def _find_standard_joint(joint: "Joint") -> "rtb.ET | None":
         std_joint = rtb.ET.SE3(SE3())
     return std_joint
 
+
 def _find_joint_ets(
     joint: "Joint",
     parent_from_Rx_to_axis: Optional[SE3] = None,
@@ -136,7 +146,7 @@ def _find_joint_ets(
     Attributes
     ----------
         joint: Joint
-            Joint from the urdf. 
+            Joint from the urdf.
             Used to deduce: transl(N), rot(N), axis(N), [Rx]
         parent_from_Rx_to_axis: Optional[SE3]
             SE3 resulting from the axis orientation of the parent joint
@@ -157,7 +167,7 @@ def _find_joint_ets(
     joint_without_axis = SE3(joint_trans) * SE3.RPY(joint_rot)
 
     std_joint = _find_standard_joint(joint)
-    is_simple_joint = std_joint is not None 
+    is_simple_joint = std_joint is not None
 
     if is_simple_joint:
         from_Rx_to_axis = SE3()
@@ -173,7 +183,7 @@ def _find_joint_ets(
 
         if joint.joint_type in ("revolute", "continuous"):
             pure_joint = rtb.ET.Rx(flip=0)
-        elif joint.joint_type == "prismatic": # I cannot test this case
+        elif joint.joint_type == "prismatic":  # I cannot test this case
             pure_joint = rtb.ET.tx(flip=0)
         else:
             pure_joint = rtb.ET.SE3(SE3())
@@ -193,6 +203,7 @@ def _find_joint_ets(
     ets = rtb.ETS(listET)
 
     return ets, from_Rx_to_axis
+
 
 class URDFType(object):
     """Abstract base class for all URDF types.
@@ -1836,9 +1847,11 @@ class URDF(URDFType):
             elink = rtb.Link(
                 name=link.name,
                 m=link.inertial.mass,
-                r=link.inertial.origin[:3, 3]
-                if link.inertial.origin is not None
-                else None,
+                r=(
+                    link.inertial.origin[:3, 3]
+                    if link.inertial.origin is not None
+                    else None
+                ),
                 I=link.inertial.inertia,
             )
             elinks.append(elink)
@@ -1870,8 +1883,8 @@ class URDF(URDFType):
             # constant part of link transform
             trans = SE3(joint.origin).t
             rot = joint.rpy
-            
-            # childlink.ets will be set later. 
+
+            # childlink.ets will be set later.
             # This is because the fully defined parent link is required
             # and this loop does not follow the parent-child order.
 

--- a/roboticstoolbox/tools/urdf/urdf.py
+++ b/roboticstoolbox/tools/urdf/urdf.py
@@ -16,9 +16,6 @@ from spatialmath.base import (
     ArrayLike3,
     getvector,
     unitvec,
-    unitvec_norm,
-    angvec2r,
-    tr2rpy,
 )
 
 from io import BytesIO
@@ -1950,11 +1947,12 @@ class URDF(URDFType):
                 SE3 resulting from the axis orientation of the parent joint
         """
         if parentname is None:
-            base_link_exists = "base_link" in [j.name for j in self.elinks]
-            if base_link_exists:
-                parentname = "base_link"
-            else:
-                parentname = self.elinks[0].name
+            # starts again with all orphan links
+            for link in self.elinks:
+                if link.parent is None:
+                    self._recursive_axis_definition(
+                        parentname=link.name, parent_from_Rx_to_axis=None
+                    )
         if parent_from_Rx_to_axis is None:
             parent_from_Rx_to_axis = SE3()
 


### PR DESCRIPTION
# Problem Overview

I discovered that rtb does not work with URDF using NOT straight axis for their joint. The Fusion CAD software tends to define its URDF export using those axis that are not only made of 0, 1 and -1. This made it impossible to load a wide variety of URDF, even though RViz and other software support those crooked axis.

For example this joint will not result in the proper link being created:
```xml
<joint name="Arm_Roll3" type="continuous">
  <origin xyz="0.280898 0.0 -0.338668" rpy="0 0 0"/>
  <parent link="Arm_PitchLink2_2"/>
  <child link="Arm_RollLink3_2"/>
  <axis xyz="0.638404 -0.0 -0.769701"/>
</joint>
```

# Faulty code

This is the piece of code that is currently responsible for creating the ets for the link representing the joint [(here in code)](https://github.com/petercorke/robotics-toolbox-python/blob/7f1bcae7e17360ea9b30a49731c2c93a219c6a19/roboticstoolbox/tools/urdf/urdf.py#L1704). The `if` case does not have any issues and is the only case covered by the tests of  the repo. The much rarer `else`, case of a crooked axis, is wrong:
```python
# Check if axis of rotation/tanslation is not 1
if np.count_nonzero(joint.axis) < 2:
    ets = rtb.ET.SE3(SE3(trans) * SE3.RPY(rot))
else:
    # Normalise the joint axis to be along or about z axis
    # Convert rest to static ETS
    v = joint.axis
    u, n = unitvec_norm(v)
    R = angvec2r(n, u)

    R_total = SE3.RPY(joint.rpy) * R
    rpy = tr2rpy(R_total)

    ets = rtb.ET.SE3(SE3(trans) * SE3.RPY(rpy))

    joint.axis = [0, 0, 1]
```

# Problem 1

Just by looking at it we can see that the math is wrong (sadly the problem does not stop there). The geometric operation performed here is: Rotate a `Rz` joint, in the plane defined by the `joint.axis`, by the length of `joint.axis`. This does not result in `Rz` being aligned with `joint.axis`.

# Problem 2

Second and much bigger problem (this is why this PR has 300 line change) is that the correct math for a link corresponding to a joint should be defined like so:
```
            ets = translation * rotation * axis * [Rx] * axis.inv()
```
`translation` and `rotation` are defined from `<origin xyz="? ? ?" rpy="? ? ?"/>`, `axis` is a rotation matrix from `[Rx]` to the axis defined in the urdf: `<axis xyz="? ? ?"/>` and `[Rx]` is a variable joint/ets from robotics-toolbox (for example `rtb.ET.Rx()`). Notice how `axis.inv()` is used. This results in `[Rx]` having an orientation (defined by `axis`), but this orientation is not propagated onto the next link.

The current code -- aside from the wrong rotation -- also does not multiply back by `axis.inv()`, and the axis orientation propagates. (this only propagates if the `else` case is used)

# Fix 1

First, I fixed the wrong rotation problem with a short function [in this commit.](https://github.com/hubble14567/robotics-toolbox-python-parser-axis-fix/commit/307fad9b216c21832cb2e661c1a5252d83b6ef7b).

# Fix 2

The big pain here is that, a link must end with a variable ets -- this is `[Rx]`. So, to have `[Rx]` at the end, we must change the formula to a recursive one using the axis of the parent. Let's call the current joint `N`, and the parent `N-1`, with this, here is the new formula for the ets:
```
            ets(N) =  axis(N-1).inv() * translation(N) * rotation(N) * axis(N) * [Rx](N)
```
If you chain those (`ets(N-1) * ets(N) * ets(N+1)`), you will get back to the first formula.

[This is implemented recursively in this (long) commit.](https://github.com/hubble14567/robotics-toolbox-python-parser-axis-fix/commit/671fbbfd9d66ad4d72acfb4c577e37c14a350f01).

Getting the ets from the joint and applying the formula is [done in this function.](https://github.com/hubble14567/robotics-toolbox-python-parser-axis-fix/blob/8094b1d5ac30420d94356624d384cb5f11009a2b/roboticstoolbox/tools/urdf/urdf.py#L132)
The recursion is [done directly inside the URDF object in this method.](https://github.com/hubble14567/robotics-toolbox-python-parser-axis-fix/blob/8094b1d5ac30420d94356624d384cb5f11009a2b/roboticstoolbox/tools/urdf/urdf.py#L1889)

I displaced almost all of the previous link creation code, only the children-parent relationship is required before the recursion where everything will be set properly [(here).](https://github.com/hubble14567/robotics-toolbox-python-parser-axis-fix/blob/8094b1d5ac30420d94356624d384cb5f11009a2b/roboticstoolbox/tools/urdf/urdf.py#L1886)

Finally,  after the proper ets is stored in the links, the other parameters of the link can be set. I initially I did the ets last to change as little code as possible, but tests did not pass, so I [had to do this commit](https://github.com/hubble14567/robotics-toolbox-python-parser-axis-fix/commit/8094b1d5ac30420d94356624d384cb5f11009a2b) to finish defining the links inside the recursion.

# PyTest

PyTest did pass successfully. Although there are warnings, but I don't know if their are related to my changes:

![image](https://github.com/petercorke/robotics-toolbox-python/assets/70491689/34dc4689-0a2a-4a96-be2f-656857409c38)
```
======================================== warnings summary ========================================
tests/test_CustomXacro.py:12
  Warning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives

tests/test_BaseRobot.py::TestBaseRobot::test_teach
tests/test_DHRobot.py::TestDHRobot::test_plot_vellipse
  Warning: divide by zero encountered in divide

tests/test_DHRobot.py::TestDHRobot::test_SerialLink
  Warning: SerialLink is deprecated, use DHRobot instead

tests/test_ELink.py::TestLink::test_collided
  Warning: base kwarg is deprecated, use pose instead

tests/test_ERobot.py::TestERobot::test_collided
tests/test_Robot.py::TestRobot::test_collided2
  Warning: method collided is deprecated, use iscollided instead

tests/test_blocks.py: 58 warnings
tests/test_mobile.py: 47 warnings
tests/test_mobile_planner.py: 118 warnings
  Warning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)

========================= 563 passed, 8 skipped, 230 warnings in 18.76s ==========================
```