### PR TITLE
Fix: Mesh filename handling

### DIFF
--- a/roboticstoolbox/tools/urdf/urdf.py
+++ b/roboticstoolbox/tools/urdf/urdf.py
@@ -302,8 +302,7 @@ class Mesh(URDFType):
 
         if value.startswith("package://"):
             value = value.replace("package://", "")
-
-        if value.startswith("file://"):
+        elif value.startswith("file://"):
             value = value.replace("file://", "")
 
         if _base_path is None:

--- a/roboticstoolbox/tools/urdf/urdf.py
+++ b/roboticstoolbox/tools/urdf/urdf.py
@@ -303,6 +303,9 @@ class Mesh(URDFType):
         if value.startswith("package://"):
             value = value.replace("package://", "")
 
+        if value.startswith("file://"):
+            value = value.replace("file://", "")
+
         if _base_path is None:
             value = rtb_path_to_datafile("xacro", value)
         else:


### PR DESCRIPTION
- Closes #442 

Many URDF files make use of the `file://` prefix when specifying filenames for loading geometry or collision meshes. For an example, refer to [this line in the xacro for the Kinova Gen3](https://github.com/Kinovarobotics/ros2_kortex/blob/cfb518085d6af6b17c1ed8bbbb372697d01b01c4/kortex_description/arms/gen3/7dof/urdf/gen3_macro.xacro#L75):
```XML
<mesh filename="file://$(find kortex_description)/arms/gen3/${dof}dof/meshes/base_link.dae" />
```

This PR Adds an explicit check for the `"file://"` prefix in `roboticstoolbox/tools/urdf/urdf.py`, alongside the existing check for `"package://"`, to handle such filenames appropriately.