### PR TITLE
remove file:// prefix if any

### DIFF
--- a/roboticstoolbox/tools/urdf/urdf.py
+++ b/roboticstoolbox/tools/urdf/urdf.py
@@ -303,6 +303,9 @@ class Mesh(URDFType):
         if value.startswith("package://"):
             value = value.replace("package://", "")
 
+        if value.startswith("file://"):
+            value = value.replace("file://", "")
+
         if _base_path is None:
             value = rtb_path_to_datafile("xacro", value)
         else:


### PR DESCRIPTION
Hi all, I encountered a bug when simulating a robot (in swift). A snippet in the URDF is like this:
```xml
    <visual>
      <origin
        xyz="0 0 -0.039"
        rpy="0 0 0" />
      <geometry>
        <mesh
          filename="file://$(find parol6)/meshes/L6.stl" />
      </geometry>
      <material
        name="">
        <color
          rgba="0.752941176470588 0.752941176470588 0.752941176470588 1" />
      </material>
    </visual>
```

I traced it and saw the problem was caused by the "file://" prefix in the mesh tag. Rtb has crafted a wrong file path to the ultimate stl file, by prefixing a path in front of the "file://". "package://" is probably a more common choice to locate a file in general, but "file://" should be a valid use case too.

I followed the same way "package://" prefix is handled. And it works like a charm now.

It's my first time trying to contribute to this great repo. I hope I'm making something of some sense :)