### PR TITLE
Add UR5e and UR20 models

### DIFF
--- a/roboticstoolbox/models/DH/UR20.py
+++ b/roboticstoolbox/models/DH/UR20.py
@@ -1,0 +1,99 @@
+import numpy as np
+from roboticstoolbox import DHRobot, RevoluteDH
+from spatialmath import SE3
+
+
+class UR20(DHRobot):
+    """
+    Class that models a Universal Robotics UR20 manipulator
+
+    :param symbolic: use symbolic constants
+    :type symbolic: bool
+
+    ``UR20()`` is an object which models a Unimation Puma560 robot and
+    describes its kinematic and dynamic characteristics using standard DH
+    conventions.
+
+    .. runblock:: pycon
+
+        >>> import roboticstoolbox as rtb
+        >>> robot = rtb.models.DH.UR20()
+        >>> print(robot)
+
+    Defined joint configurations are:
+
+    - qz, zero joint angle configuration
+    - qr, arm horizontal along x-axis
+
+    .. note::
+        - SI units are used.
+
+    :References:
+
+        - `Parameters for calculations of kinematics and dynamics <https://www.universal-robots.com/articles/ur/parameters-for-calculations-of-kinematics-and-dynamics>`_
+
+    :sealso: :func:`UR4`, :func:`UR10`
+
+
+    .. codeauthor:: Peter Corke
+    """  # noqa
+
+    def __init__(self, symbolic=False):
+
+        if symbolic:
+            import spatialmath.base.symbolic as sym
+
+            zero = sym.zero()
+            pi = sym.pi()
+        else:
+            from math import pi
+
+            zero = 0.0
+
+        deg = pi / 180
+        inch = 0.0254
+
+        # robot length values (metres)
+        a = [0, -0.8620, -0.7287, 0, 0, 0]
+        d = [0.2363, 0, 0, 0.2010, 0.1593, 0.1543]
+
+        alpha = [pi / 2, zero, zero, pi / 2, -pi / 2, zero]
+
+        # mass data, no inertia available
+        mass = [16.343, 29.632, 7.879,3.054, 3.126, 0.846]
+        center_of_mass = [
+            [0, -0.0610, 0.0062],
+            [0.5226, 0, 0.2098],
+            [0.3234, 0, 0.0604],
+            [0, -0.0026, 0.0393],
+            [0, 0.0024, 0.0379],
+            [0, -0.0003, -0.0318],
+        ]
+        links = []
+
+        for j in range(6):
+            link = RevoluteDH(
+                d=d[j], a=a[j], alpha=alpha[j], m=mass[j], r=center_of_mass[j], G=1
+            )
+            links.append(link)
+
+        super().__init__(
+            links,
+            name="UR20",
+            manufacturer="Universal Robotics",
+            keywords=("dynamics", "symbolic"),
+            symbolic=symbolic,
+        )
+
+        self.qr = np.array([180, 0, 0, 0, 90, 0]) * deg
+        self.qz = np.zeros(6)
+
+        self.addconfiguration("qr", self.qr)
+        self.addconfiguration("qz", self.qz)
+
+
+if __name__ == "__main__":  # pragma nocover
+
+    UR20 = UR20(symbolic=False)
+    print(UR20)
+    # print(UR20.dyntable())

--- a/roboticstoolbox/models/DH/UR5e.py
+++ b/roboticstoolbox/models/DH/UR5e.py
@@ -1,0 +1,99 @@
+import numpy as np
+from roboticstoolbox import DHRobot, RevoluteDH
+from spatialmath import SE3
+
+
+class UR5e(DHRobot):
+    """
+    Class that models a Universal Robotics UR5e manipulator
+
+    :param symbolic: use symbolic constants
+    :type symbolic: bool
+
+    ``UR5e()`` is an object which models a Unimation Puma560 robot and
+    describes its kinematic and dynamic characteristics using standard DH
+    conventions.
+
+    .. runblock:: pycon
+
+        >>> import roboticstoolbox as rtb
+        >>> robot = rtb.models.DH.UR5e()
+        >>> print(robot)
+
+    Defined joint configurations are:
+
+    - qz, zero joint angle configuration
+    - qr, arm horizontal along x-axis
+
+    .. note::
+        - SI units are used.
+
+    :References:
+
+        - `Parameters for calculations of kinematics and dynamics <https://www.universal-robots.com/articles/ur/parameters-for-calculations-of-kinematics-and-dynamics>`_
+
+    :sealso: :func:`UR4`, :func:`UR10`
+
+
+    .. codeauthor:: Peter Corke
+    """  # noqa
+
+    def __init__(self, symbolic=False):
+
+        if symbolic:
+            import spatialmath.base.symbolic as sym
+
+            zero = sym.zero()
+            pi = sym.pi()
+        else:
+            from math import pi
+
+            zero = 0.0
+
+        deg = pi / 180
+        inch = 0.0254
+
+        # robot length values (metres)
+        a = [0, -0.42500, -0.39225, 0, 0, 0]
+        d = [0.1625, 0, 0, 0.1333, 0.0997, 0.0996]
+
+        alpha = [pi / 2, zero, zero, pi / 2, -pi / 2, zero]
+
+        # mass data, no inertia available
+        mass = [3.761, 8.058, 2.846, 1.37, 	1.3, 0.365]
+        center_of_mass = [
+            [0, -0.02561, 0.00193],
+            [0.2125, 0, 0.11336],
+            [0.15, 0.0, 0.0265],
+            [0, -0.0018, 0.01634],
+            [0, 0.0018,0.01634],
+            [0, 0, -0.001159],
+        ]
+        links = []
+
+        for j in range(6):
+            link = RevoluteDH(
+                d=d[j], a=a[j], alpha=alpha[j], m=mass[j], r=center_of_mass[j], G=1
+            )
+            links.append(link)
+
+        super().__init__(
+            links,
+            name="UR5e",
+            manufacturer="Universal Robotics",
+            keywords=("dynamics", "symbolic"),
+            symbolic=symbolic,
+        )
+
+        self.qr = np.array([180, 0, 0, 0, 90, 0]) * deg
+        self.qz = np.zeros(6)
+
+        self.addconfiguration("qr", self.qr)
+        self.addconfiguration("qz", self.qz)
+
+
+if __name__ == "__main__":  # pragma nocover
+
+    UR5e = UR5e(symbolic=False)
+    print(UR5e)
+    # print(UR5e.dyntable())

--- a/roboticstoolbox/models/DH/__init__.py
+++ b/roboticstoolbox/models/DH/__init__.py
@@ -14,7 +14,9 @@ from roboticstoolbox.models.DH.LWR4 import LWR4
 from roboticstoolbox.models.DH.Sawyer import Sawyer
 from roboticstoolbox.models.DH.UR3 import UR3
 from roboticstoolbox.models.DH.UR5 import UR5
+from roboticstoolbox.models.DH.UR5e import UR5e
 from roboticstoolbox.models.DH.UR10 import UR10
+from roboticstoolbox.models.DH.UR20 import UR20
 from roboticstoolbox.models.DH.Mico import Mico
 from roboticstoolbox.models.DH.Jaco import Jaco
 from roboticstoolbox.models.DH.Baxter import Baxter


### PR DESCRIPTION
Since I used your library for my project and I had to add two new UR robots, I decided to create this PR for others to use.

The UR5e and UR20 have been added. The data has been extracted from here: [link](https://www.universal-robots.com/articles/ur/application-installation/dh-parameters-for-calculations-of-kinematics-and-dynamics/)
 
