### PR TITLE
Issue: Inverse Dynamics with Recursive Newton-Euler Not Working for URDF Imports

### DIFF
--- a/roboticstoolbox/robot/Robot.py
+++ b/roboticstoolbox/robot/Robot.py
@@ -1790,7 +1790,8 @@ class Robot(BaseRobot[Link], RobotKinematicsMixin):
                     v[j] = vJ
                     a[j] = Xup[j] * a_grav + SpatialAcceleration(s[j] * qddk[j])
                 else:
-                    jp = self.links[j].parent.jindex  # type: ignore
+                    parent_name = self.links[j].parent.name
+                    jp = next(i for i, link in enumerate(self.links) if link.name == parent_name)
                     v[j] = Xup[j] * v[jp] + vJ
                     a[j] = (
                         Xup[j] * a[jp] + SpatialAcceleration(s[j] * qddk[j]) + v[j] @ vJ
@@ -1804,7 +1805,8 @@ class Robot(BaseRobot[Link], RobotKinematicsMixin):
                 Q[k, j] = sum(f[j].A * s[j])
 
                 if self.links[j].parent is not None:
-                    jp = self.links[j].parent.jindex  # type: ignore
+                    parent_name = self.links[j].parent.name
+                    jp = next(i for i, link in enumerate(self.links) if link.name == parent_name)
                     f[jp] = f[jp] + Xup[j] * f[j]
 
         if l == 1:


### PR DESCRIPTION
### Problem: 
The inverse dynamics computation using the recursive Newton-Euler algorithm (rne) does not work for URDF imports and also fails for the provided Panda model:

```
import roboticstoolbox as rtb
import numpy as np

robot = rtb.models.Panda()
q = np.random.rand(robot.n)
qD = np.random.rand(robot.n)
qDD = np.random.rand(robot.n)
tau = robot.rne(q, qD, qDD)
```

### Cause of the Error:
The issue originates from the line:
`
jp = self.links[j].parent.jindex`

For certain types, parent.jindex is empty, causing the computation to fail.
Proposed Solution

### Solution:
I implemented an alternative method to find the parent index using the following approach:

`jp = next(i for i, link in enumerate(self.links) if link.name == parent_name)`

### Additional information
Roboticstoolbox version: 1.1.1
Numpy version: 1.26.4
Spatialmath version: 1.1.14
