### PR TITLE
Fix duplicate variable in null-space condition of _calc_qnull

### DIFF
--- a/roboticstoolbox/robot/IK.py
+++ b/roboticstoolbox/robot/IK.py
@@ -569,7 +569,7 @@ def _calc_qnull(
         qnull_grad += (1.0 / λm * Jm).flatten()
 
     # Calculate the null-space motion
-    if λΣ > 0 or λΣ > 0:
+    if λΣ > 0 or λm > 0:
         null_space = np.eye(ets.n) - np.linalg.pinv(J) @ J
         qnull = null_space @ qnull_grad
 

--- a/tests/test_IK.py
+++ b/tests/test_IK.py
@@ -841,6 +841,76 @@ class TestIK(unittest.TestCase):
         self.assertEqual(f, "")
 
 
+class TestCalcQnull(unittest.TestCase):
+    """Tests for _calc_qnull to verify null-space motion activation logic.
+
+    Regression tests for https://github.com/petercorke/robotics-toolbox-python/issues/499
+    The bug was a typo: `if λΣ > 0 or λΣ > 0:` instead of `if λΣ > 0 or λm > 0:`.
+    This caused null-space motion to be skipped when only km (manipulability
+    maximisation gain) was set and kq (joint limit avoidance gain) was zero.
+    """
+
+    def setUp(self):
+        from roboticstoolbox.robot.IK import _calc_qnull
+
+        self._calc_qnull = _calc_qnull
+        self.panda = rtb.models.Panda().ets()
+        self.q = np.array([0.5, -1.0, 0.3, -1.5, 0.2, 1.5, 0.5])
+        self.J = self.panda.jacob0(self.q)
+
+    def test_qnull_both_gains_zero(self):
+        """When both kq and km are zero, null-space motion should be zero."""
+        result = self._calc_qnull(
+            ets=self.panda, q=self.q, J=self.J,
+            λΣ=0.0, λm=0.0, ps=0.05, pi=0.3,
+        )
+        nt.assert_array_equal(result, np.zeros(self.panda.n))
+
+    def test_qnull_km_only(self):
+        """When only km > 0 (manipulability maximisation), null-space motion
+        should be non-zero. This is the regression test for issue #499."""
+        result = self._calc_qnull(
+            ets=self.panda, q=self.q, J=self.J,
+            λΣ=0.0, λm=1.0, ps=0.05, pi=0.3,
+        )
+        self.assertFalse(
+            np.allclose(result, 0),
+            "Null-space motion should be non-zero when km > 0, "
+            "even if kq == 0 (issue #499)",
+        )
+
+    def test_qnull_kq_only(self):
+        """When only kq > 0 (joint limit avoidance), _calc_qnull should run
+        without error and return a result with the correct shape."""
+        result = self._calc_qnull(
+            ets=self.panda, q=self.q, J=self.J,
+            λΣ=1.0, λm=0.0, ps=0.05, pi=0.3,
+        )
+        self.assertEqual(result.shape, (self.panda.n,))
+
+    def test_qnull_both_gains_positive(self):
+        """When both gains are positive, null-space motion should combine
+        joint limit avoidance and manipulability maximisation."""
+        result = self._calc_qnull(
+            ets=self.panda, q=self.q, J=self.J,
+            λΣ=1.0, λm=1.0, ps=0.05, pi=0.3,
+        )
+        self.assertEqual(result.shape, (self.panda.n,))
+
+    def test_qnull_km_only_matches_both_when_kq_inactive(self):
+        """When joint positions are far from limits (so joint limit gradient
+        is zero), km-only result should match the both-gains result."""
+        result_km = self._calc_qnull(
+            ets=self.panda, q=self.q, J=self.J,
+            λΣ=0.0, λm=1.0, ps=0.05, pi=0.3,
+        )
+        result_both = self._calc_qnull(
+            ets=self.panda, q=self.q, J=self.J,
+            λΣ=1.0, λm=1.0, ps=0.05, pi=0.3,
+        )
+        nt.assert_array_almost_equal(result_km, result_both, decimal=10)
+
+
 if __name__ == "__main__":
 
     unittest.main()


### PR DESCRIPTION
## Summary

- Fix a typo in `_calc_qnull()` where `if λΣ > 0 or λΣ > 0:` should be `if λΣ > 0 or λm > 0:`.
- This bug caused null-space motion to be skipped entirely when only `km` (manipulability maximisation) was enabled without `kq` (joint limit avoidance).
- Added 5 regression tests for `_calc_qnull` covering all gain combinations.

Fixes #499

## Root Cause

In `roboticstoolbox/robot/IK.py`, the function `_calc_qnull` has a condition that gates null-space motion calculation:

```python
# Before (buggy):
if λΣ > 0 or λΣ > 0:  # λΣ checked twice, λm never checked

# After (fixed):
if λΣ > 0 or λm > 0:  # correctly checks both gains
```

When `kq=0` (so `λΣ=0`) and `km>0` (so `λm>0`), the buggy condition evaluates to `False`, causing the null-space projection to be skipped and returning a zero vector instead of the manipulability gradient projected into the null space.

<details>
<summary>Before (with bug): qnull is all zeros when only km > 0</summary>

```
============================================================
Issue #499: Null Space Calculation Bug in _calc_qnull
============================================================

--- Test 1: Both gains zero (kq=0, km=0) ---
qnull = [0. 0. 0. 0. 0. 0. 0.]
All zeros: True

--- Test 2: Only km > 0 (kq=0, km=1) [THE BUG CASE] ---
qnull = [0. 0. 0. 0. 0. 0. 0.]
All zeros (BUG if True): True

--- Test 3: Only kq > 0 (kq=1, km=0) ---
qnull = [0. 0. 0. 0. 0. 0. 0.]
All zeros: True

--- Test 4: Both gains positive (kq=1, km=1) ---
qnull = [-0.00356543 -0.00089796 -0.00055962  0.00013665  0.00314415 -0.00055438
 -0.00219734]
All zeros: False

============================================================
Expected behavior:
  Test 2 should return NON-ZERO qnull (manipulability gradient)
  With the bug, Test 2 returns ALL ZEROS
============================================================
```

</details>

<details>
<summary>After (fixed): qnull is non-zero when km > 0</summary>

```
============================================================
Issue #499: Null Space Calculation Bug in _calc_qnull
============================================================

--- Test 1: Both gains zero (kq=0, km=0) ---
qnull = [0. 0. 0. 0. 0. 0. 0.]
All zeros: True

--- Test 2: Only km > 0 (kq=0, km=1) [THE BUG CASE] ---
qnull = [-0.00356543 -0.00089796 -0.00055962  0.00013665  0.00314415 -0.00055438
 -0.00219734]
All zeros (BUG if True): False

--- Test 3: Only kq > 0 (kq=1, km=0) ---
qnull = [0. 0. 0. 0. 0. 0. 0.]
All zeros: True

--- Test 4: Both gains positive (kq=1, km=1) ---
qnull = [-0.00356543 -0.00089796 -0.00055962  0.00013665  0.00314415 -0.00055438
 -0.00219734]
All zeros: False

============================================================
Expected behavior:
  Test 2 should return NON-ZERO qnull (manipulability gradient)
  With the bug, Test 2 returns ALL ZEROS
============================================================
```

</details>

<details>
<summary>Unit test results (5 new tests, all passing)</summary>

```
============================= test session starts ==============================
platform linux -- Python 3.11.14, pytest-9.0.2, pluggy-1.6.0 -- /home/devuser/workspace/public-oss/embodied-robotics/myenv-rtb-499/bin/python
cachedir: .pytest_cache
rootdir: /home/devuser/workspace/public-oss/embodied-robotics/robotics-toolbox-python
configfile: pyproject.toml
collecting ... collected 41 items / 36 deselected / 5 selected

tests/test_IK.py::TestCalcQnull::test_qnull_both_gains_positive PASSED   [ 20%]
tests/test_IK.py::TestCalcQnull::test_qnull_both_gains_zero PASSED       [ 40%]
tests/test_IK.py::TestCalcQnull::test_qnull_km_only PASSED               [ 60%]
tests/test_IK.py::TestCalcQnull::test_qnull_km_only_matches_both_when_kq_inactive PASSED [ 80%]
tests/test_IK.py::TestCalcQnull::test_qnull_kq_only PASSED               [100%]

======================= 5 passed, 36 deselected in 1.07s =======================
```

</details>

<details>
<summary>Full IK test suite (no regressions; 5 QP failures are pre-existing due to missing qpsolvers dependency)</summary>

```
============================= test session starts ==============================
platform linux -- Python 3.11.14, pytest-9.0.2, pluggy-1.6.0 -- /home/devuser/workspace/public-oss/embodied-robotics/myenv-rtb-499/bin/python
cachedir: .pytest_cache
rootdir: /home/devuser/workspace/public-oss/embodied-robotics/robotics-toolbox-python
configfile: pyproject.toml
collecting ... collected 41 items

tests/test_IK.py::TestIK::test_IK_GN1 PASSED                             [  2%]
tests/test_IK.py::TestIK::test_IK_GN2 PASSED                             [  4%]
tests/test_IK.py::TestIK::test_IK_GN3 PASSED                             [  7%]
tests/test_IK.py::TestIK::test_IK_LM1 PASSED                             [  9%]
tests/test_IK.py::TestIK::test_IK_LM2 PASSED                             [ 12%]
tests/test_IK.py::TestIK::test_IK_LM3 PASSED                             [ 14%]
tests/test_IK.py::TestIK::test_IK_NR1 PASSED                             [ 17%]
tests/test_IK.py::TestIK::test_IK_NR2 PASSED                             [ 19%]
tests/test_IK.py::TestIK::test_IK_NR3 PASSED                             [ 21%]
tests/test_IK.py::TestIK::test_IK_NR4 PASSED                             [ 24%]
tests/test_IK.py::TestIK::test_IK_NR5 PASSED                             [ 26%]
tests/test_IK.py::TestIK::test_IK_NR6 PASSED                             [ 29%]
tests/test_IK.py::TestIK::test_IK_NR7 PASSED                             [ 31%]
tests/test_IK.py::TestIK::test_IK_NR8 PASSED                             [ 34%]
tests/test_IK.py::TestIK::test_IK_QP1 FAILED                             [ 36%]
tests/test_IK.py::TestIK::test_IK_QP2 FAILED                             [ 39%]
tests/test_IK.py::TestIK::test_IK_QP3 FAILED                             [ 41%]
tests/test_IK.py::TestIK::test_ets_ikine_GN1 PASSED                      [ 43%]
tests/test_IK.py::TestIK::test_ets_ikine_GN2 PASSED                      [ 46%]
tests/test_IK.py::TestIK::test_ets_ikine_LM1 PASSED                      [ 48%]
tests/test_IK.py::TestIK::test_ets_ikine_LM2 PASSED                      [ 51%]
tests/test_IK.py::TestIK::test_ets_ikine_NR1 PASSED                      [ 53%]
tests/test_IK.py::TestIK::test_ets_ikine_NR2 PASSED                      [ 56%]
tests/test_IK.py::TestIK::test_ets_ikine_QP1 FAILED                      [ 58%]
tests/test_IK.py::TestIK::test_ets_ikine_QP2 FAILED                      [ 60%]
tests/test_IK.py::TestIK::test_ik_gn PASSED                              [ 63%]
tests/test_IK.py::TestIK::test_ik_lm_chan PASSED                         [ 65%]
tests/test_IK.py::TestIK::test_ik_lm_sugihara PASSED                     [ 68%]
tests/test_IK.py::TestIK::test_ik_lm_wampler PASSED                      [ 70%]
tests/test_IK.py::TestIK::test_ik_nr PASSED                              [ 73%]
tests/test_IK.py::TestIK::test_iter_iksol PASSED                         [ 75%]
tests/test_IK.py::TestIK::test_sol_print1 PASSED                         [ 78%]
tests/test_IK.py::TestIK::test_sol_print2 PASSED                         [ 80%]
tests/test_IK.py::TestIK::test_sol_print3 PASSED                         [ 82%]
tests/test_IK.py::TestIK::test_sol_print4 PASSED                         [ 85%]
tests/test_IK.py::TestIK::test_sol_print5 PASSED                         [ 87%]
tests/test_IK.py::TestCalcQnull::test_qnull_both_gains_positive PASSED   [ 90%]
tests/test_IK.py::TestCalcQnull::test_qnull_both_gains_zero PASSED       [ 92%]
tests/test_IK.py::TestCalcQnull::test_qnull_km_only PASSED               [ 95%]
tests/test_IK.py::TestCalcQnull::test_qnull_km_only_matches_both_when_kq_inactive PASSED [ 97%]
tests/test_IK.py::TestCalcQnull::test_qnull_kq_only PASSED               [100%]

=========================== short test summary info ============================
FAILED tests/test_IK.py::TestIK::test_IK_QP1 - ImportError: the package qpsolvers is required
FAILED tests/test_IK.py::TestIK::test_IK_QP2 - ImportError: the package qpsolvers is required
FAILED tests/test_IK.py::TestIK::test_IK_QP3 - ImportError: the package qpsolvers is required
FAILED tests/test_IK.py::TestIK::test_ets_ikine_QP1 - ImportError: the package qpsolvers is required
FAILED tests/test_IK.py::TestIK::test_ets_ikine_QP2 - ImportError: the package qpsolvers is required
========================= 5 failed, 36 passed in 2.70s =========================
```

</details>

## Test Plan

- [x] Verify `_calc_qnull` returns zero vector when both `kq=0` and `km=0`
- [x] Verify `_calc_qnull` returns **non-zero** vector when `km>0` and `kq=0` (the #499 regression case)
- [x] Verify `_calc_qnull` works correctly when `kq>0` and `km=0`
- [x] Verify `_calc_qnull` works correctly when both `kq>0` and `km>0`
- [x] Verify km-only result matches both-gains result when joints are far from limits
- [x] Full IK test suite passes with no regressions (5 QP failures are pre-existing)