### PR TITLE
Use quoteattr for attribute serialization (Python 3.14)

### DIFF
--- a/roboticstoolbox/tools/xacro/xmlutils.py
+++ b/roboticstoolbox/tools/xacro/xmlutils.py
@@ -31,6 +31,7 @@
 # Maintainer: Morgan Quigley <morgan@osrfoundation.org>
 
 import xml.dom.minidom
+from xml.sax.saxutils import quoteattr
 
 
 def first_child_element(elt):
@@ -120,9 +121,7 @@ def fixed_writexml(self, writer, indent="", addindent="", newl=""):   # pragma: 
     a_names = sorted(attrs.keys())
 
     for a_name in a_names:
-        writer.write(" %s=\"" % a_name)
-        xml.dom.minidom._write_data(writer, attrs[a_name].value)
-        writer.write("\"")
+        writer.write(" %s=%s" % (a_name, quoteattr(attrs[a_name].value)))
     if self.childNodes:
         if len(self.childNodes) == 1 \
            and self.childNodes[0].nodeType == xml.dom.minidom.Node.TEXT_NODE:


### PR DESCRIPTION
For Python 3.14 compat, which failed with:

```
  File "/usr/lib/python3.14/site-packages/roboticstoolbox/tools/xacro/xmlutils.py", line 124, in fixed_writexml
TypeError: _write_data() missing 1 required positional argument: 'attr'
```

We thank you in advance for your pull request, and for your interest and support of the Robotics Toolbox for Python.

You could help us a lot by:

* Making your pull request relative to the `future` branch.  This is where we fix issues and merge pull requests prior to pushing out a new release.
* Including a reference/link to any related issues.
* Providing a clear description of the problem you are addressing with the pull request, the changes proposed, and their rationale.
  * We appreciate code comments explaining what your added block of code does.
  * If your PR tackles a number of different issues, please submit multiple smaller/simpler PRs that we can individually accept or not.  Otherwise we have to ask you to modify your PR and leave some changes out. Unfortunately GH doesn't let us pick and choose.
* Making your PR as small as possible. Don't include test files, data files, or notebooks that are specific to your project; ensure that notebooks, if of general interest, are saved with output values cleared, and that robot models include only those files required.  PyPI has strict size limits on packages, and already RTB is split into a toolbox and data package.
 
