### PR TITLE
fix(deps): add coal/trimesh to dev extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,8 @@ dev = [
     "quadprog",
     "bdsim",
     "ruff",
+    "coal",
+    "trimesh",
 ]
 
 # Backward-compatible alias; notebook tooling is included in "dev".

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "scipy",
     "matplotlib",
     "ansitable",
-    "rtb-data",
+    "rtb-data @ git+https://github.com/petercorke/robotics-toolbox-python.git@main#subdirectory=rtb-data",
     "progress",
     "typing_extensions",
     "colored>2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "scipy",
     "matplotlib",
     "ansitable",
-    "rtb-data @ git+https://github.com/petercorke/robotics-toolbox-python.git@main#subdirectory=rtb-data",
+    "rtb-data",
     "progress",
     "typing_extensions",
     "colored>2.0.0",


### PR DESCRIPTION
## Summary
- `pyproject.toml` had a `collision = ["coal", "trimesh"]` extras group, but `dev` never included it
- CI's `pip install .[dev]` therefore never installs `coal`, so `test_collision.py` hard-fails (rather than skipping) on every CI run — invisible locally wherever `coal` happens to already be installed from earlier work
- Add `coal`/`trimesh` to `dev`

## Test plan
- [x] `pip install -e ".[dev]"` then `pytest tests/test_collision.py -q` — 64 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)