### PR TITLE
ci: cache robot_descriptions assets across runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,22 @@ jobs:
       - name: Install package (core, no swift)
         run: pip install .[dev]
 
+      # Model tests (Panda, PR2, UR3/5/10, Jaco, ...) load URDFs via the
+      # robot_descriptions package, which does NOT bundle the actual asset
+      # data — on first use of a given model it lazily `git clone`s a large
+      # upstream asset repo (hundreds of files) straight into this cache dir.
+      # On a fresh runner that clone happens mid-test, competing with our
+      # own --timeout=50 per test, so it's slow and occasionally flaky.
+      # Caching the directory between runs means only the very first run
+      # after this step lands pays that cost; every run after restores
+      # instantly. Bump the "v1" suffix below to force a clean re-fetch if
+      # the cache ever ends up corrupted or stale.
+      - name: Cache robot_descriptions assets
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/robot_descriptions
+          key: robot-descriptions-v1-${{ runner.os }}
+
       - name: Test (core)
         run: pytest tests/ --ignore=tests/test_blocks.py --timeout=50 --timeout_method=thread -q
 
@@ -70,6 +86,14 @@ jobs:
       - name: Install package
         run: pip install .[dev]
 
+      # See the "Cache robot_descriptions assets" step in test-core above —
+      # same reasoning, this job hits the same lazily-cloned model data.
+      - name: Cache robot_descriptions assets
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/robot_descriptions
+          key: robot-descriptions-v1-${{ runner.os }}
+
       - name: Test
         run: pytest tests/ --ignore=tests/test_blocks.py --timeout=50 --timeout_method=thread -q
 
@@ -92,6 +116,14 @@ jobs:
 
       - name: Install package
         run: pip install .[dev]
+
+      # See the "Cache robot_descriptions assets" step in test-core above —
+      # same reasoning, this job hits the same lazily-cloned model data.
+      - name: Cache robot_descriptions assets
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/robot_descriptions
+          key: robot-descriptions-v1-${{ runner.os }}
 
       - name: Run coverage
         run: pytest tests/ --ignore=tests/test_blocks.py --cov=src/roboticstoolbox --cov-report=xml:coverage.xml -q


### PR DESCRIPTION
## Summary
- Model tests (Panda, PR2, UR3/5/10, Jaco, ...) load URDFs via `robot_descriptions`, which lazily `git clone`s large upstream asset repos (hundreds of files) on first use of a given model rather than bundling the data
- On a fresh CI runner this clone happens mid-test, competing with the per-test `--timeout=50`, and shows up as `ValueError: Robot model 'X' is not available` (via #529's improved error message) even though the model exists — robot_descriptions just couldn't fetch it in time
- Cache `~/.cache/robot_descriptions` (confirmed via robot_descriptions' own source: always `os.path.expanduser("~/.cache/robot_descriptions")`, consistent across Windows/Mac/Linux) across `test-core`, `test`, and `coverage` jobs — only the first run after this lands pays the fetch cost

## Test plan
- [x] YAML validated with `python -c "import yaml; yaml.safe_load(...)"`
- [ ] This PR's own CI run is the first real test — expect the fetch to still happen once, then restore instantly on any subsequent run

🤖 Generated with [Claude Code](https://claude.com/claude-code)