### PR TITLE
ci(rtb-data): add OIDC publish workflow, bump to 2.0.0

### DIFF
--- a/.github/workflows/release-rtb-data.yml
+++ b/.github/workflows/release-rtb-data.yml
@@ -1,0 +1,92 @@
+# Build and publish the rtb-data package (robot model/mesh data files).
+# Separate from release.yml (roboticstoolbox-python) since rtb-data is an
+# independently-versioned PyPI project, published infrequently — only when
+# rtb-data/ actually changes.
+#
+# Triggered by pushing a tag matching rtb-data-v* (e.g. rtb-data-v2.0.0), or
+# manually via workflow_dispatch. Uses OIDC trusted publishing — no stored
+# PyPI token required (trusted publisher must be registered on PyPI for the
+# rtb-data project: workflow release-rtb-data.yml, environment pypi).
+
+name: Release rtb-data
+
+on:
+  push:
+    tags:
+      - "rtb-data-v*"
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  verify_version:
+    name: Verify tag matches rtb-data package version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Check version
+        # Skip check on manual workflow_dispatch runs (no tag exists)
+        if: github.event_name == 'push'
+        run: |
+          TAG="${GITHUB_REF_NAME#rtb-data-v}"
+          PKG=$(python3 -c "import tomllib; print(tomllib.load(open('rtb-data/pyproject.toml','rb'))['project']['version'])")
+          echo "Tag version : $TAG"
+          echo "Package version: $PKG"
+          [ "$TAG" = "$PKG" ] || { echo "ERROR: tag rtb-data-v$TAG does not match rtb-data/pyproject.toml version $PKG"; exit 1; }
+
+  build:
+    name: Build rtb-data sdist and wheel
+    needs: verify_version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Build
+        run: |
+          pip install build
+          python -m build --outdir dist rtb-data
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: rtb-data-dist
+          path: dist/*
+
+  smoke_test:
+    name: Smoke-test wheel install
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: rtb-data-dist
+          path: dist
+
+      - name: Install and check
+        run: |
+          pip install dist/*.whl
+          python -c "import rtbdata, os; d = os.path.dirname(rtbdata.__file__); print('OK', d); assert os.path.isdir(os.path.join(d, 'xacro', 'qut_frankie_description')); assert os.path.isdir(os.path.join(d, 'xacro', 'unimation_puma560_description'))"
+
+  upload_pypi:
+    needs: smoke_test
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # required for OIDC trusted publishing
+    steps:
+      - uses: actions/download-artifact@v7
+        with:
+          name: rtb-data-dist
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip_existing: true

--- a/rtb-data/pyproject.toml
+++ b/rtb-data/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rtb-data"
-version = "1.1.0"
+version = "2.0.0"
 description = "Data files for the Robotics Toolbox for Python."
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary
- `rtb-data` had no automated publish path — every prior release was manual. Adds `.github/workflows/release-rtb-data.yml`, tag-triggered on `rtb-data-v*`, using OIDC trusted publishing (mirrors `release.yml`'s pattern, no stored token). Requires the trusted publisher already registered on PyPI for the `rtb-data` project (done 2026-07-03: workflow `release-rtb-data.yml`, environment `pypi`).
- Bumps `rtb-data` to `2.0.0` to signal the breaking reorg (renamed/deleted model folders) already on `main`. Safe to publish now — the `1.3.x` line is pinned to `rtb-data<2` (`v1.3.1`).
- Rehearsed locally: built sdist+wheel, installed into a throwaway venv, confirmed the exact paths that were failing in CI (`qut_frankie_description/robots/panda_arm_hand.urdf.xacro`, `unimation_puma560_description/urdf/puma560_robot.urdf.xacro`) now resolve.

## Test plan
- [ ] Merge, then tag `rtb-data-v2.0.0` from `main` to trigger the new workflow
- [ ] Confirm `rtb-data 2.0.0` appears on PyPI with correct file layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)