### PR TITLE
fix(deps): add missing robot_descriptions dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "typing_extensions",
     "colored>2.0.0",
     "xacrodoc",
+    "robot_descriptions",
 ]
 
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "scipy",
     "matplotlib",
     "ansitable",
-    "rtb-data",
+    "rtb-data>=2.0",
     "progress",
     "typing_extensions",
     "colored>2.0.0",


### PR DESCRIPTION
## Summary
- `URDFRobot.py`'s `_load_rd_module()` imports `robot_descriptions.<name>_description` submodules to load models like YuMi, PR2, UR3/5/10, and Jaco — but `robot_descriptions` was never added to `pyproject.toml`, in any commit, ever.
- Every load of those models failed with `ValueError: Robot model 'X' is not available...`, which reads like a network/cache/spelling issue — it's actually just `ModuleNotFoundError` getting caught and re-raised with a friendlier (but misleading) message.
- This accounts for 13-14 of the remaining test failures on `main`'s CI, unrelated to the `rtb-data`/`coal` issues fixed elsewhere today.

## Test plan
- [x] Rehearsed locally: installed from this branch into a clean venv, loaded `rtb.models.URDF.UR5()` and `rtb.models.YuMi()` successfully (each live-clones its description repo via `robot_descriptions` on first use)
- [ ] CI: `test_UR5`, `test_UR3`, `test_UR10`, `test_pr2`, `test_Jaco`, YuMi-related tests now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)