### PR TITLE
fix(tests): fix Python 3.10-only mock.patch AttributeError in fknm fallback tests

### DIFF
--- a/tech-debt.md
+++ b/tech-debt.md
@@ -647,3 +647,39 @@ practice, re-add caching with a corrected key that includes
 `matrix.python-version` (or better, restructure so only one job per OS
 does the network fetch and others restore from it) — don't just restore
 this exact removed code.
+
+---
+
+## Python-3.10-specific workaround: `sys.modules` lookup in `test_fknm_fallback.py`
+
+### Background
+
+`tests/test_fknm_fallback.py` (2026-07-05) has a `_ETS_module =
+sys.modules["roboticstoolbox.robot.ETS"]` workaround, with a long comment
+explaining why: `roboticstoolbox/robot/ETS.py` defines a class also called
+`ETS`, `robot/__init__.py`'s `from ...ETS import ETS` shadows the
+submodule of the same name on the `roboticstoolbox.robot` package, and
+Python 3.10's `unittest.mock` resolves dotted-string `patch()` targets via
+plain `getattr` (falling back to import only on `AttributeError`) — so it
+gets fooled by the shadowing and raises `AttributeError`. Python 3.11+
+rewrote this resolution to use `pkgutil.resolve_name`, which isn't fooled.
+Not a real code bug (the actual fknm/facade fallback machinery was always
+fine) — purely a Python-3.10 `unittest.mock` limitation the test had to
+work around.
+
+Python 3.10 reaches end-of-life in **October 2026** (per the official
+CPython release schedule). `pyproject.toml`'s `requires-python = ">=3.10"`
+and the module/class name collision in `ETS.py` aren't going anywhere on
+their own, but this specific workaround exists *only* because of 3.10's
+mock behavior.
+
+### Proposed fix
+
+When `requires-python` drops support for 3.10 (naturally, around/after its
+EOL), search for this specific workaround and simplify
+`test_fknm_fallback.py` back to plain `patch("roboticstoolbox.robot.ETS.ETS_fkine", ...)`
+-style dotted strings, since 3.11+'s `pkgutil.resolve_name`-based resolution
+handles the shadowing correctly on its own. Also worth a quick sweep for
+any other `sys.version_info`/Python-3.10-specific conditionals elsewhere in
+the codebase at that point, so 3.10 cleanup happens in one pass rather than
+piecemeal.

--- a/tests/test_fknm_fallback.py
+++ b/tests/test_fknm_fallback.py
@@ -13,6 +13,7 @@ Robot used: Franka Panda (7-DOF) for ETS functions; Puma560 (6-DOF DH) for rne.
 """
 
 import os
+import sys
 import timeit
 import unittest
 from contextlib import contextmanager
@@ -23,6 +24,24 @@ import numpy.testing as nt
 import sympy
 
 import roboticstoolbox as rtb
+# roboticstoolbox/robot/ETS.py defines a class also called ETS, and
+# roboticstoolbox/robot/__init__.py does `from ...ETS import ETS`, which
+# rebinds the "ETS" attribute on the roboticstoolbox.robot package to the
+# class, shadowing the submodule of the same name. `import a.b.c as x` is
+# defined as `import a.b.c; x = a.b.c` — that second step is still
+# attribute access, so it hits the same shadowing and also gives the
+# class, not the module. sys.modules[...] is a plain dict keyed by the
+# literal dotted string, with no getattr involved, so it's the only
+# reliably-correct way to get the real module object here.
+#
+# This only matters for patch() at all because Python 3.10's
+# unittest.mock resolves dotted string patch targets via plain getattr
+# (falling back to import only on AttributeError), so
+# patch("...ETS.ETS_fkine", ...) resolves "ETS" to the shadowing class
+# and fails with AttributeError; 3.11+ uses pkgutil.resolve_name and
+# isn't fooled. patch.object() against the real module (via sys.modules)
+# works on every version.
+_ETS_module = sys.modules["roboticstoolbox.robot.ETS"]
 from spatialmath import SE3
 
 
@@ -57,7 +76,7 @@ def _no_c_fkine():
     def _py(fknm, q, base, tool, include_base, _data=None):
         return _python_fkine(_data, q, base, tool, include_base)
 
-    with patch("roboticstoolbox.robot.ETS.ETS_fkine", new=_py):
+    with patch.object(_ETS_module, "ETS_fkine", new=_py):
         yield
 
 
@@ -69,7 +88,7 @@ def _no_c_jacob0():
     def _py(fknm, q, tool, _data=None, _n=None):
         return _python_jacob0(_data, _n, q, tool)
 
-    with patch("roboticstoolbox.robot.ETS.ETS_jacob0", new=_py):
+    with patch.object(_ETS_module, "ETS_jacob0", new=_py):
         yield
 
 
@@ -81,7 +100,7 @@ def _no_c_jacobe():
     def _py(fknm, q, tool, _data=None, _n=None):
         return _python_jacobe(_data, _n, q, tool)
 
-    with patch("roboticstoolbox.robot.ETS.ETS_jacobe", new=_py):
+    with patch.object(_ETS_module, "ETS_jacobe", new=_py):
         yield
 
 
@@ -101,7 +120,7 @@ def _no_c_hessian0():
             verifymatrix(J0, (6, _n))
         return _python_hessian(J0)
 
-    with patch("roboticstoolbox.robot.ETS.ETS_hessian0", new=_py):
+    with patch.object(_ETS_module, "ETS_hessian0", new=_py):
         yield
 
 
@@ -121,7 +140,7 @@ def _no_c_hessiane():
             verifymatrix(Je, (6, _n))
         return _python_hessian(Je)
 
-    with patch("roboticstoolbox.robot.ETS.ETS_hessiane", new=_py):
+    with patch.object(_ETS_module, "ETS_hessiane", new=_py):
         yield
 
 


### PR DESCRIPTION
## Summary
Root-caused the Python-3.10-only `AttributeError: <class 'roboticstoolbox.robot.ETS.ETS'> does not have the attribute 'ETS_jacob0'` (and jacobe/hessian0/hessiane/fkine) seen on `main`'s CI. **Not a real code bug** — the actual fknm C-extension/pure-Python fallback machinery was fine the whole time.

The actual cause: `roboticstoolbox/robot/ETS.py` defines a class also called `ETS`, and `robot/__init__.py`'s `from ...ETS import ETS` rebinds the `"ETS"` attribute on the `roboticstoolbox.robot` package to the class, shadowing the submodule of the same name. Python 3.10's `unittest.mock` resolves dotted-string `patch()` targets via plain `getattr` (falling back to import only on `AttributeError`), so `patch("...ETS.ETS_fkine", ...)` resolved `"ETS"` to the shadowing class and failed. Python 3.11+ rewrote this to use `pkgutil.resolve_name`, which isn't fooled by the same shadowing — hence it only ever showed up on 3.10.

Fix: look up the real module via `sys.modules["roboticstoolbox.robot.ETS"]` (a plain dict keyed by the literal string, no `getattr` involved — even `import ... as x` doesn't avoid the shadowing, since that's defined as `import ...; x = ...`, still attribute access) and use `patch.object()` against that instead of a dotted string.

## Test plan
- [x] All 41 tests in `test_fknm_fallback.py` pass under Python 3.10
- [x] All 41 tests pass under Python 3.13 (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)