### PR TITLE
fix(mobile): guard VehicleDriverBase against workspace=None

### DIFF
--- a/src/roboticstoolbox/mobile/Vehicle.py
+++ b/src/roboticstoolbox/mobile/Vehicle.py
@@ -371,7 +371,7 @@ class VehicleBase(ABC):
 
             >>> from roboticstoolbox import Bicycle, RandomPath
             >>> bike = Bicycle()
-            >>> bike.control = RandomPath(10)
+            >>> bike.control = RandomPath(workspace=10)
             >>> print(bike)
 
         :seealso: :meth:`run` :meth:`eval_control` :obj:`scipy.interpolate.interp1d` :class:`~roboticstoolbox.mobile.drivers.VehicleDriverBase`

--- a/src/roboticstoolbox/mobile/drivers.py
+++ b/src/roboticstoolbox/mobile/drivers.py
@@ -58,7 +58,13 @@ class VehicleDriverBase(ABC):
         [A, B, C, D]     A:B      C:D
         ==============  =======  =======
         """
-        if hasattr(workspace, "workspace"):
+        if workspace is None:
+            # spatialmath.base.expand_dims(None) raises TypeError despite
+            # None being its own advertised default (see tech-debt.md in
+            # the spatialmath-python repo) — treat "no workspace" as None
+            # rather than relying on that default.
+            self._workspace = None
+        elif hasattr(workspace, "workspace"):
             # workspace can be defined by an object with a workspace attribute
             self._workspace = base.expand_dims(workspace.workspace)
         else:


### PR DESCRIPTION
## Summary
- `VehicleDriverBase.__init__` crashed whenever `workspace` was left at its own default (`None`), because `spatialmath.base.expand_dims(None)` raises `TypeError` despite advertising `None` as its default (tracked upstream in spatialmath-python's tech-debt.md).
- Fixed the docstring runblock example that surfaced this: `RandomPath(10)` passed `10` positionally into `dthresh`, not `workspace` (which only exists via `**kwargs`). Now `RandomPath(workspace=10)`.

## Test plan
- [x] Rehearsed in a clean venv: `RandomPath(workspace=10)` construction + `print(bike)` succeeds end-to-end
- [x] `pytest tests/ -k "mobile or Vehicle or driver"` — 25 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)