### PR TITLE
fix(models): make KinovaGen3 load via robot_descriptions, add XACRO_ARGS support

### DIFF
--- a/src/roboticstoolbox/models/URDF/KinovaGen3.py
+++ b/src/roboticstoolbox/models/URDF/KinovaGen3.py
@@ -31,7 +31,7 @@ class KinovaGen3(URDFRobot):
 
     def __init__(self):
         super().__init__(
-            "kortex_description/robots/gen3.xacro",
+            "gen3",
             manufacturer="Kinova",
             gripper_link_index=10,
         )

--- a/src/roboticstoolbox/models/URDF/URDFRobot.py
+++ b/src/roboticstoolbox/models/URDF/URDFRobot.py
@@ -116,7 +116,7 @@ def _load_rd_module(robot_name: str):
     ) from last_error
 
 
-def _load_urdf_from_RD(robot_name: str) -> Path:
+def _load_urdf_from_RD(robot_name: str) -> "tuple[Path, dict | None]":
     """Fetch the URDF/xacro path from robot_descriptions and register its packages.
 
     robot_descriptions models expose different path attributes depending on their
@@ -125,6 +125,13 @@ def _load_urdf_from_RD(robot_name: str) -> Path:
       - XACRO_PATH — a xacro source that must be processed by xacrodoc
                      (e.g. j2n6s200, ur5, kinova family)
     Both are passed to XacroDoc.from_file(), which handles either format.
+
+    Some xacro-based models also expose ``XACRO_ARGS`` — substitution
+    values required to compile the file at all (e.g. Kinova Gen3's
+    ``{"dof": "7"}``, which selects the 6dof/7dof arm variant; several UR
+    and xArm variants have the same pattern). Returned alongside the path
+    so the caller can forward them to xacrodoc as ``subargs`` — without
+    them, xacro fails on an unresolved ``$(arg ...)``/property reference.
     """
     module = _load_rd_module(robot_name)
 
@@ -138,7 +145,7 @@ def _load_urdf_from_RD(robot_name: str) -> Path:
             "URDF_PATH nor XACRO_PATH."
         )
     _register_rd_packages(urdf_path)
-    return urdf_path
+    return urdf_path, getattr(module, "XACRO_ARGS", None)
 
 
 def _parse_urdf(urdf_str: str):
@@ -272,17 +279,18 @@ def URDF_file(file: "str | Path | TextIO", model: "str | None" = None) -> tuple:
     pkg_map = {d.name: str(d) for d in xacro_root.iterdir() if d.is_dir()}
     packages.update_package_cache(pkg_map)
 
+    xacro_args = None
     if isinstance(file, str):
         file = Path(file)
         if file.suffix not in (".urdf", ".xacro"):
-            file = Path(_load_urdf_from_RD(str(file)))
+            file, xacro_args = _load_urdf_from_RD(str(file))
 
     resolved_path = None
     if isinstance(file, Path):
         if not file.is_absolute():
             file = xacro_root / file
         resolved_path = file
-        doc = XacroDoc.from_file(file)
+        doc = XacroDoc.from_file(file, subargs=xacro_args)
     else:
         doc = XacroDoc.from_string(file.read())
 


### PR DESCRIPTION
## Summary
- `KinovaGen3()` always raised `FileNotFoundError`: it pointed at `"kortex_description/robots/gen3.xacro"` in the bundled `rtb-data` xacro tree, which has no `kortex_description` folder at all.
- `robot_descriptions` does have a working `gen3_description` entry (repo `ros2_kortex`), but its xacro file needs a substitution argument to select the 6dof/7dof arm variant — it exposes `XACRO_ARGS = {"dof": "7"}` alongside `XACRO_PATH`. `_load_urdf_from_RD()` only ever read `URDF_PATH`/`XACRO_PATH` and silently dropped `XACRO_ARGS`, so even switching to RD naively would still fail on an unresolved xacro property.
- This gap likely affects other RD models exposing `XACRO_ARGS` too (several UR/xArm/FR3/Rizon variants), though gen3 is the first one this toolbox actually hits.
- Fix: thread `XACRO_ARGS` through as `XacroDoc`'s `subargs`, and switch `KinovaGen3.py` to the bare `"gen3"` RD lookup instead of the missing bundled path.

## Test plan
- [x] `rtb.models.URDF.KinovaGen3()` constructs and prints correctly (7-DOF arm, matches docstring's `qr`/`qz` exactly)
- [x] Full test suite: 652 passed, 13 skipped, no regressions
- [x] Regression-checked every other RD-loaded model (Jaco, PR2, UR3/5/10, YuMi, Frankie) still constructs fine with the new `subargs=None` passthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)