### PR TITLE
fix(test): specify encoding=utf-8 reading BaseRobot.py/pyproject.toml

### DIFF
--- a/tests/test_backend_capabilities.py
+++ b/tests/test_backend_capabilities.py
@@ -178,7 +178,7 @@ class TestBaseRobotNoModuleLevelMPLImport(unittest.TestCase):
             "robot",
             "BaseRobot.py",
         )
-        with open(os.path.normpath(base_robot_path)) as f:
+        with open(os.path.normpath(base_robot_path), encoding="utf-8") as f:
             source = f.read()
 
         tree = ast.parse(source)
@@ -231,7 +231,7 @@ class TestBaseRobotNoModuleLevelMPLImport(unittest.TestCase):
                 "BaseRobot.py",
             )
         )
-        with open(base_robot_path) as f:
+        with open(base_robot_path, encoding="utf-8") as f:
             source = f.read()
 
         tree = ast.parse(source)
@@ -257,7 +257,7 @@ class TestWebsocketsPin(unittest.TestCase):
         toml_path = os.path.normpath(
             os.path.join(os.path.dirname(__file__), "..", "pyproject.toml")
         )
-        with open(toml_path) as f:
+        with open(toml_path, encoding="utf-8") as f:
             content = f.read()
         self.assertNotIn(
             "websockets<11",


### PR DESCRIPTION
## Summary
- `main` itself is currently failing CI on every Windows job (confirmed via `gh run list --branch main` — latest run's conclusion is `failure`), which was also failing identically on every one of #541-#546 since they all inherit from `main`.
- Root cause: `tests/test_backend_capabilities.py` opens `BaseRobot.py` (twice) and `pyproject.toml` with plain `open(path)` — no encoding specified. Windows defaults to the locale codepage (cp1252) rather than UTF-8. `BaseRobot.py`'s docstrings contain a stylized Unicode math italic "𝜋" (U+1D70B), which cp1252 can't decode → `UnicodeDecodeError` on every Windows job, every PR.
- Fix: add `encoding="utf-8"` to all three `open()` calls. Confirmed these were the only unencoded `open()` calls in `tests/`.
- Note: macOS jobs on some of these PRs also show failures, but that's the already-documented, unrelated `test_IK_GN3` numerical flakiness (tech-debt.md) — not touched by this PR.

## Test plan
- [x] `pytest tests/test_backend_capabilities.py` — 21 passed, 4 skipped
- [x] Full suite: 652 passed, 13 skipped, no regressions
- [x] Can't reproduce the Windows-specific default-codepage behavior on macOS directly, but the fix (explicit `encoding="utf-8"`) is correct on every platform regardless — it's the only way to guarantee the file (an actual UTF-8 source file) decodes correctly no matter the OS locale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)