### PR TITLE
fix(mobile): gate driveto()'s per-step print behind verbose flag

### DIFF
--- a/src/roboticstoolbox/mobile/drivers.py
+++ b/src/roboticstoolbox/mobile/drivers.py
@@ -147,10 +147,11 @@ class VehicleDriverBase(ABC):
 
         goal_heading = atan2(goal[1] - self._veh._x[1], goal[0] - self._veh._x[0])
         delta_heading = base.angdiff(goal_heading, self._veh._x[2])
-        print(
-            f"t={self._veh._t:.1f}, pos=({self._veh._x[0]:.1f}, {self._veh._x[1]:.1f}), ",
-            f"goal_heading={goal_heading * 180 / pi:.1f}, delta_heading={delta_heading * 180 / pi:.1f}",
-        )
+        if self._veh.verbose or self._verbose:
+            print(
+                f"t={self._veh._t:.1f}, pos=({self._veh._x[0]:.1f}, {self._veh._x[1]:.1f}), ",
+                f"goal_heading={goal_heading * 180 / pi:.1f}, delta_heading={delta_heading * 180 / pi:.1f}",
+            )
 
         return np.r_[self._speed, self._headinggain * delta_heading]
 


### PR DESCRIPTION
## Summary
`VehicleDriverBase.driveto()` prints an unconditional status line on every call — any simulation longer than a couple of steps floods stdout. `RandomPath._new_goal()` right below it already gates its print behind `self._veh.verbose or self._verbose`; `driveto()` just never got the same treatment. Found while building a working EKF/RandomPath example for a docs update.

## Test plan
- [x] Ran a 20s EKF dead-reckoning simulation (`Bicycle` + `RandomPath`) — clean output, no per-step spam
- [x] Full test suite: 653 passed, 13 skipped, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)