### PR TITLE
docs(fix): resolve stale jointset references and joints() forward-ref warning

### DIFF
--- a/docs/source/arm_ets.rst
+++ b/docs/source/arm_ets.rst
@@ -70,7 +70,7 @@ ETS - 3D
 --------
 
 .. autoclass:: roboticstoolbox.ets.ETS.ETS
-   :members: __str__, __repr__, __mul__, __getitem__, n, m, structure, joints, jointset, split, inv, compile, insert, fkine, jacob0, jacobe, hessian0, hessiane
+   :members: __str__, __repr__, __mul__, __getitem__, n, m, structure, joints, jindex_set, split, inv, compile, insert, fkine, jacob0, jacobe, hessian0, hessiane
    :undoc-members:
    :show-inheritance:
    :member-order: bysource
@@ -79,7 +79,7 @@ ETS - 2D
 --------
 
 .. autoclass:: roboticstoolbox.ets.ETS2.ETS2
-   :members: __str__, __repr__, __mul__, __getitem__, n, m, structure, joints, jointset, split, inv, compile, insert, fkine, jacob0, jacobe
+   :members: __str__, __repr__, __mul__, __getitem__, n, m, structure, joints, jindex_set, split, inv, compile, insert, fkine, jacob0, jacobe
    :undoc-members:
    :show-inheritance:
 

--- a/src/roboticstoolbox/ets/_ETS.py
+++ b/src/roboticstoolbox/ets/_ETS.py
@@ -281,12 +281,12 @@ class BaseETS(MutableSequence):
 
         return np.where([e.isjoint for e in self])[0]  # type: ignore
 
-    def joints(self) -> list[ET]:
+    def joints(self) -> list[BaseET]:
         """
         Get a list of the variable ETs with this ETS
 
         :returns: list of ETs that are joints
-        :rtype: list[ET]
+        :rtype: list[BaseET]
 
         Examples
         --------
@@ -372,7 +372,7 @@ class BaseETS(MutableSequence):
 
             >>> from roboticstoolbox import ET
             >>> e = ET.Rz(jindex=1) * ET.tx(jindex=2) * ET.Rz(jindex=1) * ET.tx(1)
-            >>> e.jointset()
+            >>> e.jindex_set()
 
         """
 
@@ -393,7 +393,7 @@ class BaseETS(MutableSequence):
 
             >>> from roboticstoolbox import ET
             >>> e = ET.Rz(jindex=1) * ET.tx(jindex=2) * ET.Rz(jindex=1) * ET.tx(1)
-            >>> e.jointset()
+            >>> e.jindices
 
         """
 


### PR DESCRIPTION
## Summary

- `jointset()` was renamed to `jindex_set()` back in 2022 (`f3bc1392`) — the tests were updated then, but `arm_ets.rst`'s `:members:` list and two docstring examples inside `_ETS.py` (`BaseETS.jindex_set`/`.jindices`) were never updated, still referencing a method that hasn't existed for three years.
- Fixed `BaseETS.joints()`'s return type: `-> list[ET]` referenced the concrete 3D `ET` class, which `_ETS.py` never imports (it only imports the shared `BaseET` — correct, since this method lives on the base class shared by both `ETS` and `ETS2`). `sphinx_autodoc_typehints` fails to resolve it, producing "name 'ET' is not defined" for both `ETS.ETS.joints` and `ETS2.ETS2.joints` (same inherited method). Corrected to `list[BaseET]`.
- Investigated resurrecting the older `9922d07d` "resolve reST syntax and structural Sphinx build warnings" commit as well — turned out its entire scope is already satisfied on `main` (the `eta`→`param`/`axis`→`kind` renames and the ET/ETS package split all had to rewrite the same docstring blocks it would have fixed, and did so correctly formatted; `docs/intro-restructure` independently already covered the `conf.py`/template fixes). No changes needed there.

## Test plan

- [x] Full suite green (620 passed, 72 skipped).
- [x] Sphinx build warnings down from 8 → 4 (remaining: `KinematicCache`, `SensorBase`, a guarded matplotlib `Color` import — unrelated, pre-existing, left for another pass).