### PR TITLE
feat(rtbtool): add 'tool' extra for IPython/pygments

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ Available options are:
 - `swift` install [Swift](https://github.com/jhavl/swift), a web-based visualizer
 - `qp` install quadratic-programming IK dependencies (`qpsolvers`, `quadprog`)
 - `collision` install collision checking with [coal](https://github.com/coal-library/coal) and `trimesh`
-- `all` install `swift`, `qp`, and `collision`
+- `tool` install `IPython` and `pygments`, needed to run the `rtbtool` interactive shell
+- `all` install `swift`, `qp`, `collision`, and `tool`
 
 > **Windows note:** `coal` does not publish Windows wheels on PyPI, so the
 > `collision`/`all` extras skip it there and collision checking is
@@ -155,7 +156,13 @@ pip install roboticstoolbox-python[qp]
 pip install roboticstoolbox-python[collision]
 ```
 
-- Everything (swift + qp + collision)
+- `rtbtool` interactive shell dependencies only
+
+```shell script
+pip install roboticstoolbox-python[tool]
+```
+
+- Everything (swift + qp + collision + tool)
 
 ```shell script
 pip install roboticstoolbox-python[all]

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -16,7 +16,8 @@ Available extras:
 - ``swift`` install `Swift <https://github.com/jhavl/swift>`_, a web-based visualizer
 - ``qp`` install quadratic-programming IK dependencies (``qpsolvers``, ``quadprog``)
 - ``collision`` install collision checking with `coal <https://github.com/coal-library/coal>`_ and ``trimesh``
-- ``all`` install ``swift``, ``qp``, and ``collision``
+- ``tool`` install ``IPython`` and ``pygments``, needed to run the ``rtbtool`` interactive shell
+- ``all`` install ``swift``, ``qp``, ``collision``, and ``tool``
 
 .. warning:: ``coal`` does not publish Windows wheels on PyPI, so the
     ``collision``/``all`` extras skip it on Windows and collision checking
@@ -46,7 +47,11 @@ Install matrix:
 
     pip install roboticstoolbox-python[collision]
 
-- Everything (swift + qp + collision)::
+- ``rtbtool`` interactive shell dependencies only::
+
+    pip install roboticstoolbox-python[tool]
+
+- Everything (swift + qp + collision + tool)::
 
     pip install roboticstoolbox-python[all]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,8 @@ collision = ["coal; sys_platform != 'win32'", "trimesh"]
 
 qp = ["qpsolvers", "quadprog"]
 
+tool = ["ipython", "pygments"]
+
 all = [
     "swift-sim>=1.0.0",
     "websockets",
@@ -83,6 +85,8 @@ all = [
     "quadprog",
     "coal; sys_platform != 'win32'",
     "trimesh",
+    "ipython",
+    "pygments",
 ]
 
 dev = [

--- a/src/roboticstoolbox/bin/rtbtool.py
+++ b/src/roboticstoolbox/bin/rtbtool.py
@@ -10,11 +10,6 @@ Usage::
 """
 
 # import stuff
-from pygments.token import Token
-from IPython.terminal.prompts import Prompts
-from IPython.terminal.prompts import ClassicPrompts
-from traitlets.config import Config
-import IPython
 import argparse
 from pathlib import Path
 import shlex
@@ -221,6 +216,17 @@ def startup():
 
 
 def main():
+    try:
+        import IPython
+        from IPython.terminal.prompts import Prompts
+        from pygments.token import Token
+        from traitlets.config import Config
+    except ImportError as e:
+        sys.exit(
+            f"rtbtool requires IPython and pygments, which are not "
+            f"installed ({e}).\nInstall them with:\n\n"
+            "    pip install roboticstoolbox-python[tool]\n"
+        )
 
     args, ipython_args = parse_arguments()
 


### PR DESCRIPTION
## Summary
- `rtbtool` imported `IPython`, `pygments`, and `traitlets` unconditionally at module scope, but none were declared as a dependency anywhere — `pip install roboticstoolbox-python` followed by running `rtbtool` crashed with a raw `ModuleNotFoundError` unless IPython happened to already be present transitively (e.g. via Jupyter).
- Moved the imports into `main()`, guarded by a try/except that points the user at a new `tool` extra (`pip install roboticstoolbox-python[tool]`) instead of a bare traceback.
- Added `tool = ["ipython", "pygments"]` to `pyproject.toml`, folded into `all`, and documented in README.md/docs/source/install.rst alongside the existing `swift`/`qp`/`collision` extras.
- Companion fix applied to MVTB's `mvtbtool` (same gap) in a separate PR.

## Test plan
- [x] Simulated missing IPython/pygments → clean error message pointing at `pip install roboticstoolbox-python[tool]`
- [x] Normal run (`python -m roboticstoolbox.bin.rtbtool --no-banner`) still drops into an IPython shell correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)