### PR TITLE
fix: use spatialgeometry's correctly-spelled _propagate_scene_tree()

### DIFF
--- a/src/roboticstoolbox/robot/Link.py
+++ b/src/roboticstoolbox/robot/Link.py
@@ -1101,8 +1101,8 @@ class BaseLink(SceneNode, ABC):
 
         if not skip:
             self.robot._update_link_tf(self.robot.q)  # type: ignore
-            self._propogate_scene_tree()
-            shape._propogate_scene_tree()
+            self._propagate_scene_tree()
+            shape._propagate_scene_tree()
 
         d = 10000
         p1 = None
@@ -1134,8 +1134,8 @@ class BaseLink(SceneNode, ABC):
 
         if not skip:
             self.robot._update_link_tf(self.robot.q)  # type: ignore
-            self._propogate_scene_tree()
-            shape._propogate_scene_tree()
+            self._propagate_scene_tree()
+            shape._propagate_scene_tree()
 
         for col in self.collision:
             if col.iscollided(shape):

--- a/src/roboticstoolbox/robot/Link.py
+++ b/src/roboticstoolbox/robot/Link.py
@@ -1101,8 +1101,8 @@ class BaseLink(SceneNode, ABC):
 
         if not skip:
             self.robot._update_link_tf(self.robot.q)  # type: ignore
-            self._propagate_scene_tree()
-            shape._propagate_scene_tree()
+            self.update()
+            shape.update()
 
         d = 10000
         p1 = None
@@ -1134,8 +1134,8 @@ class BaseLink(SceneNode, ABC):
 
         if not skip:
             self.robot._update_link_tf(self.robot.q)  # type: ignore
-            self._propagate_scene_tree()
-            shape._propagate_scene_tree()
+            self.update()
+            shape.update()
 
         for col in self.collision:
             if col.iscollided(shape):

--- a/src/roboticstoolbox/robot/Robot.py
+++ b/src/roboticstoolbox/robot/Robot.py
@@ -1289,8 +1289,8 @@ class Robot(BaseRobot[Link], RobotKinematicsMixin):
 
         if not skip:
             self._update_link_tf(q)
-            self._propagate_scene_tree()
-            shape._propagate_scene_tree()
+            self.update()
+            shape.update()
 
         d = 10000
         p1 = None
@@ -1324,8 +1324,8 @@ class Robot(BaseRobot[Link], RobotKinematicsMixin):
 
         if not skip:
             self._update_link_tf(q)
-            self._propagate_scene_tree()
-            shape._propagate_scene_tree()
+            self.update()
+            shape.update()
 
         for link in self.links:
             if link.iscollided(shape, skip=True):

--- a/src/roboticstoolbox/robot/Robot.py
+++ b/src/roboticstoolbox/robot/Robot.py
@@ -1289,8 +1289,8 @@ class Robot(BaseRobot[Link], RobotKinematicsMixin):
 
         if not skip:
             self._update_link_tf(q)
-            self._propogate_scene_tree()
-            shape._propogate_scene_tree()
+            self._propagate_scene_tree()
+            shape._propagate_scene_tree()
 
         d = 10000
         p1 = None
@@ -1324,8 +1324,8 @@ class Robot(BaseRobot[Link], RobotKinematicsMixin):
 
         if not skip:
             self._update_link_tf(q)
-            self._propogate_scene_tree()
-            shape._propogate_scene_tree()
+            self._propagate_scene_tree()
+            shape._propagate_scene_tree()
 
         for link in self.links:
             if link.iscollided(shape, skip=True):


### PR DESCRIPTION
## Summary

`spatialgeometry`'s `_propogate_scene_tree()` was a plain misspelling of
"propagate" -- see [jhavl/spatialgeometry#38](https://github.com/jhavl/spatialgeometry/pull/38).
That PR was amended before merging: rather than landing a correctly-spelled
but still-private `_propagate_scene_tree()` only to deprecate it again
immediately after, it went straight to a public `update()` method.
`_propogate_scene_tree()` (the original misspelled name this repo called)
remains available as a deprecated (`FutureWarning`) alias for back-compat,
but this migrates `Link.py`'s and `Robot.py`'s 8 call sites to call
`update()` directly instead.

Not touching this repo's own vendored `src/spatialgeometry/` snapshot --
that's separate, deliberate legacy left alone for now.

## Test plan

- [x] Confirmed no collision with any existing RTB method: grepped the
  whole `roboticstoolbox` tree for `def update(` -- only unrelated local
  functions elsewhere (PyPlot backends, `mobile/Animations.py`), none on
  `Robot`/`Link` or anywhere in their MRO
- [x] Confirmed live: `rtb.Robot.update is spatialgeometry.SceneNode.update`
  is `True`
- [ ] Hit an unrelated, pre-existing failure constructing a full URDF robot
  (`Panda()`) in this environment: `Link.py` calls
  `SceneGroup(scene_children=geometry)` directly, which doesn't match
  `SceneGroup`'s actual constructor (`initlist`, not `scene_children`) --
  a separate API mismatch, nothing to do with this change. Not chased down
  per your steer on `test_Robot.py`'s existing ~34 unrelated failures.