### PR TITLE
fix(mobile): DistanceTransformPlanner.next() calls undefined Error()

### DIFF
--- a/src/roboticstoolbox/mobile/DistanceTransformPlanner.py
+++ b/src/roboticstoolbox/mobile/DistanceTransformPlanner.py
@@ -154,7 +154,7 @@ class DistanceTransformPlanner(PlannerBase):
         :seealso: :meth:`plan` :meth:`query`
         """
         if self.distancemap is None:
-            Error("No distance map computed, you need to plan.")
+            raise ValueError("No distance map computed, you need to plan.")
 
         directions = np.array(
             [

--- a/tests/test_distance_transform_plot.py
+++ b/tests/test_distance_transform_plot.py
@@ -1,0 +1,27 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+import roboticstoolbox as rtb
+
+
+def test_distance_transform_plot_colorbar_without_explicit_axes():
+    floorplan = np.zeros((10, 10), dtype=int)
+    floorplan[4:7, 4:7] = 1
+
+    planner = rtb.DistanceTransformPlanner(floorplan, inflate=1)
+    planner.plan((8, 8))
+
+    # Regression test: colorbar creation must not require caller-provided axes.
+    planner.plot(block=False)
+    plt.close("all")
+
+
+def test_distance_transform_next_before_plan_raises():
+    # Regression test: next() used to call the undefined name Error(...)
+    # instead of raising, so calling it before plan() crashed with
+    # NameError rather than the intended ValueError.
+    floorplan = np.zeros((10, 10), dtype=int)
+    planner = rtb.DistanceTransformPlanner(floorplan, inflate=1)
+
+    with pytest.raises(ValueError, match="No distance map computed"):
+        planner.next((0, 0))


### PR DESCRIPTION
## Summary

\`next()\` called \`Error("No distance map computed, you need to plan.")\`
instead of raising it -- \`Error\` isn't a builtin or ever imported, so this
crashed with \`NameError\` instead of the intended \`ValueError\` whenever
\`next()\` was called before \`plan()\`.

Reported in #507 (2026-01-18), which also removed an unrelated
\`from numpy import disp\` -- that half is already independently fixed
(NumPy 2.0 dropped \`numpy.disp\`, and the current file no longer imports it).
Fixes #507.

## Test plan

- [x] New regression test: \`test_distance_transform_next_before_plan_raises\`
- [x] Full local suite green