### PR TITLE
fix: drop stale ax= kwarg from ArmPlot's robot.plot() call

### DIFF
--- a/src/roboticstoolbox/blocks/arm.py
+++ b/src/roboticstoolbox/blocks/arm.py
@@ -416,7 +416,6 @@ class ArmPlot(GraphicsBlock):
             self.q0,
             backend=self.backend,
             fig=self.fig,
-            ax=self.ax,
             block=False,
         )
 


### PR DESCRIPTION
## Summary

`BaseRobot.plot()` no longer accepts an `ax=` parameter — only `fig=` is
real and documented; `ax` isn't referenced anywhere in its body, and
flows straight through into `env.add()`, whose signature (`PyPlot.add()`)
has never accepted `ax` either.

`roboticstoolbox/blocks/arm.py`'s `ArmPlot.start()` asserts
`self.ax is not None` and then passes `ax=self.ax` into `robot.plot()`,
raising:

```
TypeError: PyPlot.add() got an unexpected keyword argument 'ax'
```

`self.ax` isn't used anywhere else in `arm.py` — dropping it from this
one call site is sufficient; `robot.plot()` manages its own axes
internally given `fig=`.

Found while investigating a bdsim block-diagram example (from
RVC3-python, the RVC book's companion repo) that used to work in 2022 —
this was the second of two stacked bugs blocking it end-to-end, the first
being bdsim's own `PROD(matrix=True)` removal (unrelated, fixed on the
notebook side, not an RTB issue).

## Test plan

- [x] `tests/test_blocks.py`: 22 passed, 6 skipped, no failures (none of
      these previously exercised this exact `ArmPlot.start()` code path,
      which is how this went unnoticed)
- [x] Real reproduction: RVC3-python's `RVC3/models/RRMC.py` (a bdsim
      block-diagram simulation using `ARMPLOT`) now runs end-to-end and
      produces the expected `out.clock0.t`/`.x` results, where it
      previously crashed at `plot.start`