### PR TITLE
fix: rtbtool's %precision line spuriously echoes its own return value

### DIFF
--- a/src/roboticstoolbox/bin/rtbtool.py
+++ b/src/roboticstoolbox/bin/rtbtool.py
@@ -382,7 +382,8 @@ def main():
     if code is None:
         code = [
             "startup()",
-            "%precision %.3g",
+            "_prec = get_ipython().run_line_magic('precision', '%.3g'); "
+            "print(f'Default numeric formatting: {_prec}')",
         ]
     else:
         code.append("plt.ion()")


### PR DESCRIPTION
## Summary
- `rtbtool`'s default startup `exec_lines` end with a bare `%precision %.3g` as the last statement. IPython auto-displays the last bare-expression result by default (independent of `--showassign`), so every default `rtbtool` session prints a spurious `Out[1]: '%.3g'` right before the first real prompt.
- Fixed by wrapping the magic call in `get_ipython().run_line_magic(...)`, assigning the result, and printing it explicitly with a clear label — so the line's last statement is a `print()` call, which is never auto-displayed.

Found while doing the equivalent fix in RVC3-python's `rvctool` (same class of bug, same root cause) — `mvtbtool` has a related but currently-latent version of this (only manifests with `--showassign`), tracked separately.

## Test plan
- [x] `rtbtool --no-banner` (default startup) — confirmed no more `Out[1]: '%.3g'`, shows `Default numeric formatting: %.3g` instead
- [x] `pytest tests/test_bin.py` — all 7 pass