### PR TITLE
fix(teach):  update of vellipse and fellipse

### DIFF
--- a/src/roboticstoolbox/robot/BaseRobot.py
+++ b/src/roboticstoolbox/robot/BaseRobot.py
@@ -2225,11 +2225,13 @@ class BaseRobot(SceneNode, DynamicsMixin, RobotPlottingMPLMixin, ABC, Generic[Li
         already_blocked = env._add_teach_panel(self, q, handle, block)
 
         if vellipse:
-            vell = self.vellipse(q, centre="ee", scale=0.5, add=False)
+            vell = self.vellipse(q, centre="ee", add=False)
+            env._teach_vellipse = vell
             env.add(vell)
 
         if fellipse:
             fell = self.fellipse(q, centre="ee", add=False)
+            env._teach_fellipse = fell
             env.add(fell)
 
         # Keep the plot open -- skipped if the backend already blocked


### PR DESCRIPTION
### Problem
When `robot.teach(..., vellipse=True)` is used, moving a joint slider updates the robot visualization but leaves the velocity ellipse at its initial configuration.

The teach-panel callback already attempts to update a stored velocity ellipse, but the ellipse created by `teach()` is not assigned to that backend reference and the callback cannot update the ellipse when the joint sliders change.

### Changes
- Store the velocity ellipse created by `teach() `as the teach-panel ellipse.
- Store the force ellipse similarly when `fellipse=True`.

### Rationale
The plotting backend already contains the update mechanism for teach-panel ellipses. Assigning the objects when they are created connects that mechanism to the ellipses displayed by `teach()`.

### Related issues
No related issue found.