### PR TITLE
fix: ShapePlot uses SG Shape.base (removed) instead of .T for pose

### DIFF
--- a/src/roboticstoolbox/backends/PyPlot/EllipsePlot.py
+++ b/src/roboticstoolbox/backends/PyPlot/EllipsePlot.py
@@ -8,6 +8,7 @@ import warnings
 
 # import scipy as sp
 from spatialmath import base
+from spatialmath import SE3
 import matplotlib.pyplot as plt
 
 
@@ -37,12 +38,14 @@ class ShapePlot:
         if self.shape.stype == "cuboid":
             # scale
             self.mpl = base.plot_cuboid(
-                sides=self.shape.scale, pose=self.shape.base, ax=ax
+                sides=self.shape.scale, pose=SE3(self.shape.T, check=False), ax=ax
             )
 
         elif self.shape.stype == "sphere":
-            print(self.shape.base.t)
-            self.mpl = base.plot_sphere(self.shape.radius, pose=self.shape.base, ax=ax)
+            # print(self.shape.base.t)
+            self.mpl = base.plot_sphere(
+                self.shape.radius, pose=SE3(self.shape.T, check=False), ax=ax
+            )
 
         elif self.shape.stype == "cylinder":
             # radius, length


### PR DESCRIPTION
## Summary
- SpatialGeometry's `Shape` no longer exposes a `.base` attribute -- only `.T` (a plain `ndarray`), with `base=` remaining only as a deprecated constructor kwarg alias for `pose=`/`T`.
- `ShapePlot.draw()` in `EllipsePlot.py` was still reading `self.shape.base` post-construction for cuboid/sphere rendering, breaking with `AttributeError`.
- Fixed by wrapping `self.shape.T` in `SE3(..., check=False)` -- `plot_cuboid`/`plot_sphere` genuinely need an `SE3` object, not a raw array (`plot_cuboid` does `pose.A`; `plot_sphere`'s `_render3D` does `pose * points`, which would have silently done elementwise ndarray math instead of an SE3 transform on a raw array -- no error, just wrong output).
- Also commented out a stray `print(self.shape.base.t)` debug line that broke the same way.

Found while root-causing a `PyPlot` backend crash in RVC3-python's `walking.py` example (`env.add(Cuboid(...))`).

## Test plan
- [x] Reproduced the original crash directly via `RVC3/examples/walking.py` (RVC3-python), confirmed root cause against the installed SpatialGeometry `Shape` class
- [x] Applied the fix, re-ran `walking.py` end-to-end -- runs clean past the previous crash point through the full gait-walk loop