### PR TITLE
fix: deprecate Bicycle block's vlim/slim kwargs instead of erroring

### DIFF
--- a/src/roboticstoolbox/blocks/mobile.py
+++ b/src/roboticstoolbox/blocks/mobile.py
@@ -1,4 +1,5 @@
 from typing import Type
+import warnings
 import numpy as np
 from math import sin, cos, atan2, tan, sqrt, pi
 
@@ -81,9 +82,30 @@ class Bicycle(ContinuousBlock):
         :type x0: array_like(3), optional
         :param blockargs: |BlockOptions|
         :type blockargs: dict
+
+        .. deprecated:: the ``vlim`` and ``slim`` keywords are deprecated,
+            use ``speed_max`` and ``steer_max`` instead.
         """
         # TODO: add option to model the effect of steering arms, responds to
         #  gamma dot
+
+        vlim = blockargs.pop("vlim", None)
+        if vlim is not None:
+            warnings.warn(
+                "vlim is deprecated, use speed_max instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            speed_max = vlim
+
+        slim = blockargs.pop("slim", None)
+        if slim is not None:
+            warnings.warn(
+                "slim is deprecated, use steer_max instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            steer_max = slim
 
         super().__init__(nstates=3, **blockargs)
         self.type = "bicycle"

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -285,6 +285,13 @@ class MobileBlockTest(unittest.TestCase):
             [10 * np.cos(x[2]), 10 * np.sin(x[2]), 10 / 3 * np.tan(0.3)],
         )
 
+    def test_bicycle_vlim_slim_deprecated(self):
+
+        with self.assertWarns(DeprecationWarning):
+            block = Bicycle(vlim=2, slim=1.3)
+        self.assertEqual(block.vehicle.speed_max, 2)
+        self.assertEqual(block.vehicle.steer_max, 1.3)
+
     def test_unicycle(self):
 
         x = [2, 3, np.pi / 2]


### PR DESCRIPTION
## Summary
- The bdsim `Bicycle` block's `vlim`/`slim` kwargs were renamed to `speed_max`/`steer_max` in df5529f5 (2021) with no deprecation shim -- any diagram or script still using the old names hits an opaque `BlockCreationError` from bdsim's block-creation wrapper instead of a clear signal to update.
- Restores the old kwargs as a deprecated alias: passing `vlim`/`slim` now emits a `DeprecationWarning` and maps onto `speed_max`/`steer_max`.
- Found via RVC3-python's `driveconfig.py` (book Fig 4.14), which still used the pre-2021 kwargs and was failing outright.

## Test plan
- [x] `pytest tests/test_blocks.py tests/test_mobile.py` -- 39 passed, 6 skipped
- [x] New `test_bicycle_vlim_slim_deprecated` asserts the warning fires and values map through correctly
- [x] Verified `RVC3-python/RVC3/models/driveconfig.py` runs end-to-end against this branch (previously failed with `BlockCreationError`)