### PR TITLE
ci: add "All tests passed" aggregator job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,19 @@ jobs:
       - name: Test
         run: pytest tests/ --ignore=tests/test_blocks.py --timeout=50 --timeout_method=thread -q
 
+  all-tests-passed:
+    name: All tests passed
+    needs: [test-core, test]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check test job results
+        run: |
+          if [ "${{ needs.test-core.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ]; then
+            echo "test-core: ${{ needs.test-core.result }}, test: ${{ needs.test.result }}"
+            exit 1
+          fi
+
   coverage:
     needs: [test-core, test]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds an `all-tests-passed` job to `ci.yml` that gates on `test-core` + `test` both succeeding, mirroring MVTB's `ci.yml` pattern (their `all-tests-passed` job needing `test`).
- Purpose: give branch protection on `main` a single, stable required-status-check name ("All tests passed") instead of having to enumerate every OS/Python matrix leg individually as a required context -- brittle since the matrix changes over time.

Follow-up (not in this PR): set branch protection on `main` requiring this check, `strict` (branch must be up to date), `enforce_admins: false` -- so PR merges are gated on CI but direct pushes remain at Peter's discretion per AGENTS.md.

## Test plan
- [ ] CI run on this PR itself exercises the new job -- confirm "All tests passed" appears and goes green alongside the rest.