### PR TITLE
fix: deprecate RangeBearingSensor's animate kwarg instead of erroring

### DIFF
--- a/src/roboticstoolbox/mobile/sensors.py
+++ b/src/roboticstoolbox/mobile/sensors.py
@@ -1,4 +1,5 @@
 from abc import ABC
+import warnings
 import numpy as np
 import scipy as sp
 from math import pi, sin, cos
@@ -56,6 +57,7 @@ class SensorBase(ABC):
         delay=0.1,
         seed=0,
         verbose=False,
+        **kwargs,
     ):
         """Sensor.Sensor Sensor object constructor
         %
@@ -73,6 +75,12 @@ class SensorBase(ABC):
         # - Animation shows a ray from the vehicle position to the selected
         #   landmark.
         """
+        if kwargs:
+            raise TypeError(
+                f"SensorBase.__init__() got unexpected keyword argument(s): "
+                f"{', '.join(kwargs)}"
+            )
+
         self._robot = robot
         self._map = map
         self._every = every
@@ -266,9 +274,19 @@ class RangeBearingSensor(SensorBase):
             >>> print(sensor)
 
         :seealso: :class:`~roboticstoolbox.mobile.LandmarkMap` :class:`~roboticstoolbox.mobile.EKF`
+
+        .. deprecated:: the ``animate`` keyword is deprecated, use ``plot``
+            instead.
         """
 
-        # TODO change plot option to animate, but RVC3 uses plot
+        animate = kwargs.pop("animate", None)
+        if animate is not None:
+            warnings.warn(
+                "animate is deprecated, use plot instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            plot = animate
 
         # call the superclass constructor
         super().__init__(robot, map, **kwargs)

--- a/tests/test_mobile.py
+++ b/tests/test_mobile.py
@@ -108,6 +108,15 @@ class RangeBearingSensorTest(unittest.TestCase):
 
         self.assertIsInstance(str(self.rs), str)
 
+    def test_animate_deprecated(self):
+
+        with self.assertWarns(DeprecationWarning):
+            rs = RangeBearingSensor(self.veh, self.map, animate=True)
+        self.assertTrue(rs._animate)
+
+        with self.assertRaises(TypeError):
+            RangeBearingSensor(self.veh, self.map, bogus_kwarg=True)
+
     def test_reading(self):
 
         z, lm_id = self.rs.reading()


### PR DESCRIPTION
## Summary
- \`SensorBase\`'s \`animate\` kwarg was renamed to \`plot\` in 68292aef/93be21f9 (2023) with no deprecation shim -- \`RangeBearingSensor(..., animate=True)\` now hits an opaque \`TypeError\` instead of a clear signal to update. A leftover comment at the old call site (\`# TODO change plot option to animate, but RVC3 uses plot\`) shows this was known at the time and only partially addressed -- one of six \`RangeBearingSensor\` call sites in the RVC3 book's own chap6 notebook was updated to \`plot=\`, the other four were missed.
- Restores \`animate\` as a deprecated alias on \`RangeBearingSensor\` (where \`self._animate\` is actually finalized): passing \`animate=\` now emits a \`DeprecationWarning\` and maps onto \`plot\`.
- Also tightens \`SensorBase.__init__\` to explicitly reject any other unrecognized kwarg with a clear \`TypeError\`, rather than silently accepting arbitrary kwargs.
- Related: while investigating this, found \`EKF.py\` and \`SensorBase\` have no live test coverage at all (#597) -- exactly why this and the \`Bicycle\` \`vlim\`/\`slim\` rename (#596) both went unnoticed for years.

## Test plan
- [x] \`pytest tests/test_mobile.py\` -- 17 passed
- [x] New \`test_animate_deprecated\` asserts the warning fires, the value maps through to \`_animate\`, and an unrelated bogus kwarg still raises \`TypeError\`