### PR TITLE
fix: install swift/spatialgeometry from jhavl upstream, not petercorke's stale forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,8 @@ jobs:
       - name: Install spatialgeometry + swift from source (NumPy 2 compatible)
         run: |
             pip install "websockets<11"
-            pip install --no-cache-dir git+https://github.com/petercorke/spatialgeometry.git@future
-            pip install --no-cache-dir git+https://github.com/petercorke/swift.git@future
+            pip install git+https://github.com/jhavl/spatialgeometry.git@future
+            pip install git+https://github.com/jhavl/swift.git@future
 
       - name: Install package
         run: pip install .[dev]
@@ -126,8 +126,8 @@ jobs:
       - name: Install spatialgeometry + swift from source (NumPy 2 compatible)
         run: |
           pip install "websockets<11"
-          pip install --no-cache-dir git+https://github.com/petercorke/spatialgeometry.git@future
-          pip install --no-cache-dir git+https://github.com/petercorke/swift.git@future
+          pip install git+https://github.com/jhavl/spatialgeometry.git@future
+          pip install git+https://github.com/jhavl/swift.git@future
 
       - name: Install package
         run: pip install .[dev]
@@ -153,8 +153,8 @@ jobs:
       - name: Install spatialgeometry + swift from source (NumPy 2 compatible)
         run: |
           pip install "websockets<11"
-          pip install --no-cache-dir git+https://github.com/petercorke/spatialgeometry.git@future
-          pip install --no-cache-dir git+https://github.com/petercorke/swift.git@future
+          pip install git+https://github.com/jhavl/spatialgeometry.git@future
+          pip install git+https://github.com/jhavl/swift.git@future
 
       - name: Install docs dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,8 @@ jobs:
       - name: Install spatialgeometry + swift from source (NumPy 2 compatible)
         run: |
             pip install "websockets<11"
-            pip install git+https://github.com/petercorke/spatialgeometry.git@future
-            pip install git+https://github.com/petercorke/swift.git@future
+            pip install --no-cache-dir git+https://github.com/petercorke/spatialgeometry.git@future
+            pip install --no-cache-dir git+https://github.com/petercorke/swift.git@future
 
       - name: Install package
         run: pip install .[dev]
@@ -126,8 +126,8 @@ jobs:
       - name: Install spatialgeometry + swift from source (NumPy 2 compatible)
         run: |
           pip install "websockets<11"
-          pip install git+https://github.com/petercorke/spatialgeometry.git@future
-          pip install git+https://github.com/petercorke/swift.git@future
+          pip install --no-cache-dir git+https://github.com/petercorke/spatialgeometry.git@future
+          pip install --no-cache-dir git+https://github.com/petercorke/swift.git@future
 
       - name: Install package
         run: pip install .[dev]
@@ -153,8 +153,8 @@ jobs:
       - name: Install spatialgeometry + swift from source (NumPy 2 compatible)
         run: |
           pip install "websockets<11"
-          pip install git+https://github.com/petercorke/spatialgeometry.git@future
-          pip install git+https://github.com/petercorke/swift.git@future
+          pip install --no-cache-dir git+https://github.com/petercorke/spatialgeometry.git@future
+          pip install --no-cache-dir git+https://github.com/petercorke/swift.git@future
 
       - name: Install docs dependencies
         run: |


### PR DESCRIPTION
## Summary

**Corrected diagnosis** -- the first commit on this PR was wrong (kept for the record rather than force-pushed away; the second commit explains and fixes it properly).

`ci.yml` installs `spatialgeometry`/`swift` unpinned in three jobs (`test`, `coverage`, `docs-build`) from:
```
git+https://github.com/petercorke/spatialgeometry.git@future
git+https://github.com/petercorke/swift.git@future
```
Those are **Peter's personal forks**, not the real upstream repos (`jhavl/swift`, `jhavl/spatialgeometry`) where all actual development happens -- including #600's `SWIFT_HEADLESS` dependency, [jhavl/swift#122](https://github.com/jhavl/swift/pull/122). Both forks have drifted out of sync with upstream: `petercorke/swift`'s `future` was 64 commits behind (traced back to roughly PR #75-era on the real repo); `petercorke/spatialgeometry`'s `future` was behind too, by a smaller margin that just hadn't broken a test yet.

Confirmed directly via `git ls-remote` against each URL, live -- no pip cache involved anywhere. Fix: point all six install lines (2 packages x 3 jobs) at `jhavl/swift`/`jhavl/spatialgeometry` instead.

## Test plan
- [x] `git ls-remote https://github.com/jhavl/swift.git future` / `.../jhavl/spatialgeometry.git future` both resolve to current tip
- [x] CI on this PR is the real test -- the `test` job's swift install should now match `jhavl/swift`'s actual current HEAD