### PR TITLE
docs: track docs/source/_templates/layout.html

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,0 +1,10 @@
+{% extends "!layout.html" %}
+{% block footer %}
+{{ super() }}
+<div style="text-align: center; padding: 0.4em 0 0.8em; font-size: 0.85em; color: #aaa;">
+    <a href="https://github.com/petercorke/robotics-toolbox-python" target="_blank" rel="noopener noreferrer"
+        style="color: #aaa; text-decoration: underline;">
+        View on GitHub
+    </a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
`docs/source/_templates/layout.html` is referenced by `conf.py`'s `templates_path = ["_templates"]` but was never actually committed -- it overrides the Sphinx theme footer with a "View on GitHub" link. The deployed docs site has presumably been missing that link the whole time; only local builds ever had it, since this file only ever existed on disk here.

Found while sorting out a batch of stray untracked files in the repo root.

## Test plan
- [ ] `docs-build` CI job on this PR builds cleanly with the template present