### PR TITLE
chore: retire the stale future branch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@ We thank you in advance for your pull request, and for your interest and support
 
 You could help us a lot by:
 
-* Making your pull request relative to the `future` branch.  This is where we fix issues and merge pull requests prior to pushing out a new release.
+* Making your pull request relative to the `main` branch.
 * Including a reference/link to any related issues.
 * Providing a clear description of the problem you are addressing with the pull request, the changes proposed, and their rationale.
   * We appreciate code comments explaining what your added block of code does.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # Run tests, coverage, and build docs across all supported platforms
-# Triggers on pushes/PRs to main and the active dev branch.
+# Triggers on pushes/PRs to main.
 #
 # spatialgeometry and swift-sim are installed from GitHub HEAD because the
 # current PyPI releases were compiled against NumPy 1.x and crash under 2.x.
@@ -10,9 +10,9 @@ name: CI
 
 on:
   push:
-    branches: [main, future]
+    branches: [main]
   pull_request:
-    branches: [main, future]
+    branches: [main]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ K. He, R. Newbury, T. Tran, J. Haviland, B. Burgess-Limerick, D. Kulić, P. Cork
 
 <p>
   <a href="https://youtu.be/vobLvg4E3kM">
-    <img src="https://raw.githubusercontent.com/petercorke/robotics-toolbox-python/future/docs/figs/vmc_youtube.png" width="560">
+    <img src="https://raw.githubusercontent.com/petercorke/robotics-toolbox-python/main/docs/figs/vmc_youtube.png" width="560">
   </a>
 </p>
 


### PR DESCRIPTION
## Summary
- \`future\` was 162 commits behind \`main\`, 0 ahead, last touched 2026-06-14 -- a leftover from before RTB used a proper PR-based workflow, no longer part of how anything actually merges.
- Confirmed via MVTB and bdsim (Peter's other actively-maintained repos): both already dropped their own \`future\` branches entirely. RTB was the outlier still carrying it.
- Third-party repos (\`swift\`, \`spatialgeometry\`) still use their own \`future\` branch as the live PR-merge target, set by their own owners -- unrelated, not touched here.

Changes:
- \`ci.yml\`: drop \`future\` from \`push\`/\`pull_request\` trigger branches
- \`pull_request_template.md\`: stop telling contributors to target \`future\`
- \`README.md\`: fix a stray image URL pointing at \`future/docs/figs/...\` -- would have 404'd once the branch is actually deleted

## Test plan
- [x] PR #594 (the only open PR targeting \`future\`) retargeted to \`main\` separately, so it won't be orphaned
- [ ] After merge: delete the \`future\` branch on GitHub (holding off until explicitly confirmed, since it's a destructive remote action)