### PR TITLE
docs: describe robot_descriptions integration and catalog()

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,26 @@ while not arrived:
 	<img src="./docs/figs/panda3.gif">
 </p>
 
+### Loading models from robot_descriptions
+
+The Panda example above uses one of the ~50 models shipped with the Toolbox, but many more
+robots are available on demand via the [robot_descriptions](https://github.com/robot-descriptions/robot_descriptions.py)
+package, which is installed automatically as a dependency. Passing a bare name (no file suffix)
+to `URDFRobot` fetches and loads it from there:
+
+```python
+from roboticstoolbox.models.URDF.URDFRobot import URDFRobot
+ur5 = URDFRobot("ur5")
+```
+
+`rtb.models.catalog()` lists everything available — the models built into the Toolbox as well
+as those it can load from `robot_descriptions` — with filtering by keyword/DoF/model type and
+column sorting:
+
+```python
+rtb.models.catalog(mtype="URDF", sorton="name")
+```
+
 ### Run some examples
 
 The [`notebooks`](https://github.com/petercorke/robotics-toolbox-python/tree/main/notebooks) folder contains some tutorial Jupyter notebooks which you can browse on GitHub. Additionally, have a look in the [`examples`](https://github.com/petercorke/robotics-toolbox-python/tree/main/roboticstoolbox/examples) folder for many ready to run examples.

--- a/docs/source/arm_models.rst
+++ b/docs/source/arm_models.rst
@@ -1,6 +1,12 @@
 Manipulator models
 ==================
 
+Listing available models
+-------------------------
+
+.. automodule:: roboticstoolbox.models.catalog
+   :members:
+
 .. toctree::
    :maxdepth: 2
 

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -243,8 +243,44 @@ To load an arbitrary URDF or xacro file we can use::
 which will preprocess and parse the file, and loads any associated mesh assets.
 
 If `filename` is a plain name with no suffix, like `"ur5"`, the Toolbox will attempt to dynamically load
-the model from the `robot_descriptions <https://github.com/robot-descriptions/robot_descriptions.py>`_ package, which is a collection of URDF and xacro files for many robots.  
+the model from the `robot_descriptions <https://github.com/robot-descriptions/robot_descriptions.py>`_ package, which is a collection of URDF and xacro files for many robots.
 This package is installed automatically with RTB-P.
+
+To see what's available -- both the models shipped with the Toolbox and those it can load
+on demand from ``robot_descriptions`` -- use :func:`~roboticstoolbox.models.catalog.catalog`::
+
+    >>> from roboticstoolbox.models import catalog
+    >>> catalog(dof=6, mtype="URDF", sorton="name")
+
+.. code-block:: text
+
+    ┌─────────┬────────────┬────────────────────┬────────────┬─────┬──────┬──────────────────┬──────────┬──────────┬──────────┐
+    │  class  │ robot name │    manufacturer    │ model type │ DoF │ dims │        structure │ dynamics │ geometry │ keywords │
+    ├─────────┼────────────┼────────────────────┼────────────┼─────┼──────┼──────────────────┼──────────┼──────────┼──────────┤
+    │ Puma560 │ Puma560    │ Unimation          │ URDF       │ 6   │ 3d   │ RRRRRR           │          │ Y        │          │
+    │ UR10    │ ur10       │ Universal Robotics │ URDF       │ 6   │ 3d   │ RRRRRR           │ Y        │ Y        │          │
+    │ UR3     │ ur3        │ Universal Robotics │ URDF       │ 6   │ 3d   │ RRRRRR           │ Y        │ Y        │          │
+    │ UR5     │ ur5        │ Universal Robotics │ URDF       │ 6   │ 3d   │ RRRRRR           │ Y        │ Y        │          │
+    └─────────┴────────────┴────────────────────┴────────────┴─────┴──────┴──────────────────┴──────────┴──────────┴──────────┘
+
+    Importable from robot_descriptions:
+
+    ┌─────────────────────────┬────────────┬───────────────┬────────────┬─────┬────────────────┐
+    │ robot_descriptions name │ robot name │ manufacturer  │ model type │ DoF │    keywords    │
+    ├─────────────────────────┼────────────┼───────────────┼────────────┼─────┼────────────────┤
+    │ bolt                    │ Bolt       │ ODRI          │ URDF       │ 6   │ biped          │
+    │ skydio_x2               │ Skydio X2  │ Skydio        │ URDF       │ 6   │ drone          │
+    │ upkie                   │ Upkie      │ Tast's Robots │ URDF       │ 6   │ biped, wheeled │
+    └─────────────────────────┴────────────┴───────────────┴────────────┴─────┴────────────────┘
+
+This example is shown as static text rather than a live-executed block: the
+``robot_descriptions`` listing runs to hundreds of rows unfiltered, and the real output
+embeds a terminal hyperlink escape sequence around "robot_descriptions" that only
+degrades gracefully in an interactive terminal, not in captured/static output.
+
+The listing can be filtered by ``keywords`` or ``dof``, and sorted on ``name``, ``manufacturer``
+or ``dof``. Rows in the ``robot_descriptions`` table give the name to pass to ``URDFRobot()``, e.g.
+``URDFRobot("bolt")`` for the Bolt above, not the class name shown for Toolbox-wrapped models.
 
 
 Trajectories


### PR DESCRIPTION
Thanks for contributing to RTB!

## Summary

`catalog()` (the built-in-models + `robot_descriptions` listing, with keyword/DoF/type filters and column sorting) and `URDFRobot`'s bare-name auto-load from `robot_descriptions` were both implemented but never documented anywhere beyond a one-line mention in `intro.rst`.

- README: short example loading a `robot_descriptions` model + `catalog()`
- `intro.rst`: expand the `robot_descriptions` paragraph, add a `catalog()` example (static `code-block`, not a live `runblock` — the real output embeds an OSC-8 terminal hyperlink escape sequence around "robot_descriptions" that only degrades gracefully in an interactive terminal, and the unfiltered listing runs to hundreds of rows)
- `arm_models.rst`: add an `automodule` entry for `models.catalog` so the new `intro.rst` cross-reference resolves, and the function gets a proper API doc page

Verified: full local Sphinx build before/after this change reports the same 66 pre-existing warnings, zero new ones introduced.

## Related issue

<!-- Fixes #123 / Closes #123 — if applicable -->

## Checklist

Only the first item below is checked automatically — the rest are a self-check for you before requesting review, nothing currently verifies them for you.

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`type: description`) — checked automatically, see the "Check PR title" status
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for this change, if applicable
- [x] New/changed code is type-hinted with modern syntax (`X | Y`, `list[X]`, not `Union`/`Optional`/`List`)
- [x] Docstrings updated (reST style: `:param:`, `:returns:`; type hints in the signature cover types now, `:type:`/`:rtype:` are rarely needed)
- [x] PR is as small/focused as practical — if it tackles several unrelated things, consider splitting it so each can be reviewed and accepted independently
- [x] No test files, data files, or notebooks specific to your own project — PyPI has strict package size limits, and RTB is already split into a toolbox and a data package. Notebooks, if of general interest, should have output cleared before committing.

<!-- Target branch is `main`. -->