### PR TITLE
docs: fix dead wiki/Common-Issues links, point at wiki/FAQ

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Common issues
-    url: https://github.com/petercorke/robotics-toolbox-python/wiki/Common-Issues
+  - name: FAQ / Common issues
+    url: https://github.com/petercorke/robotics-toolbox-python/wiki/FAQ
     about: Check here first — your issue may already have a known fix or workaround.
   - name: Ask a question
     url: https://github.com/petercorke/robotics-toolbox-python/discussions

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ copy the following
 
 ## Common Issues and Solutions
 
-See the common issues with fixes [here](https://github.com/petercorke/robotics-toolbox-python/wiki/Common-Issues).
+See the common issues with fixes [here](https://github.com/petercorke/robotics-toolbox-python/wiki/FAQ).
 
 ### Using the Toolbox with Windows?
 


### PR DESCRIPTION
Thanks for contributing to RTB!

## Summary

`Common-Issues.md` was just merged into `FAQ.md` on the wiki (the wiki doesn't use PRs, so that change isn't tracked in this repo's git history — it's a separate `.wiki.git` repo). This updates the two places in this repo that linked to the old page:

- `README.md`'s "Common Issues and Solutions" section
- `.github/ISSUE_TEMPLATE/config.yml`'s contact link

Note: the wiki-side FAQ merge is pushed separately (not gated on this PR) — `wiki/FAQ` already exists as a page either way, so this link never 404s, it just points at a stub until that push lands.

## Related issue

<!-- Fixes #123 / Closes #123 — if applicable -->

## Checklist

Only the first item below is checked automatically — the rest are a self-check for you before requesting review, nothing currently verifies them for you.

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`type: description`) — checked automatically, see the "Check PR title" status
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for this change, if applicable
- [x] New/changed code is type-hinted with modern syntax (`X | Y`, `list[X]`, not `Union`/`Optional`/`List`)
- [x] Docstrings updated (reST style: `:param:`, `:returns:`; type hints in the signature cover types now, `:type:`/`:rtype:` are rarely needed)
- [x] PR is as small/focused as practical — if it tackles several unrelated things, consider splitting it so each can be reviewed and accepted independently
- [x] No test files, data files, or notebooks specific to your own project — PyPI has strict package size limits, and RTB is already split into a toolbox and a data package. Notebooks, if of general interest, should have output cleared before committing.

<!-- Target branch is `main`. -->