### PR TITLE
fix: resolve all 9 Sphinx build warnings

### DIFF
--- a/docs/source/arm_superclass.rst
+++ b/docs/source/arm_superclass.rst
@@ -18,16 +18,6 @@ The various models :ref:`E Models` all subclass this class.
    :inherited-members:
    :special-members: __getitem__
 
-Kinematic cache
----------------
-
-.. automodule:: roboticstoolbox.robot.KinematicCache
-   :members:
-   :undoc-members:
-   :show-inheritance:
-   :inherited-members:
-   :special-members: __init__
-   
 Link
 ----
 

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -34,14 +34,14 @@ To specify a kinematic model using DH notation, we create a new Robot instance a
 a list of DH link objects.  For example, a Puma560 is simply::
 
     >>> robot = DHRobot(
-        [
-            RevoluteDH(alpha=pi/2),
-            RevoluteDH(a=0.4318),
-            RevoluteDH(d=0.15005, a=0.0203, alpha=-pi/2),
-            RevoluteDH(d=0.4318, alpha=pi/2),
-            RevoluteDH(alpha=-pi/2),
-            RevoluteDH()
-        ], name="Puma560")
+    ...     [
+    ...         RevoluteDH(alpha=pi/2),
+    ...         RevoluteDH(a=0.4318),
+    ...         RevoluteDH(d=0.15005, a=0.0203, alpha=-pi/2),
+    ...         RevoluteDH(d=0.4318, alpha=pi/2),
+    ...         RevoluteDH(alpha=-pi/2),
+    ...         RevoluteDH()
+    ...     ], name="Puma560")
 
 
 where only the non-zero parameters need to be specified. In this case we used

--- a/src/roboticstoolbox/mobile/__init__.py
+++ b/src/roboticstoolbox/mobile/__init__.py
@@ -24,7 +24,7 @@ from roboticstoolbox.mobile.OccGrid import (
 
 # localization and state estimation
 from roboticstoolbox.mobile.landmarkmap import LandmarkMap
-from roboticstoolbox.mobile.sensors import RangeBearingSensor
+from roboticstoolbox.mobile.sensors import SensorBase, RangeBearingSensor
 from roboticstoolbox.mobile.drivers import *
 from roboticstoolbox.mobile.Animations import (
     VehicleAnimationBase,
@@ -59,6 +59,7 @@ __all__ = [
     "RandomPath",
     "PurePursuit",
     "LandmarkMap",
+    "SensorBase",
     "RangeBearingSensor",
     "PoseGraph",
     "PolygonMap",

--- a/src/roboticstoolbox/robot/Dynamics.py
+++ b/src/roboticstoolbox/robot/Dynamics.py
@@ -265,7 +265,7 @@ class DynamicsMixin:
         >>> def myfunc(robot, t, q, qd, qstar, P, D):
         >>>     return (qstar - q) * P + qd * D  # P, D are (6,)
 
-        >>> tg = robot.fdyn(10, q0, myfunc, torque_args=(qstar, P, D)) )
+        >>> tg = robot.fdyn(10, q0, myfunc, torque_args=(qstar, P, D))
 
         Many integrators have variable step length which is problematic if we
         want to animate the result.  If ``dt`` is specified then the solver


### PR DESCRIPTION
Thanks for contributing to RTB!

## Summary

Categorized and fixed every warning from a full local Sphinx build (was 9, now 0):

- **`arm_superclass.rst`**: removed the `automodule` block for `roboticstoolbox.robot.KinematicCache` — that class/module was deleted from the codebase a while back, the doc directive was never cleaned up
- **`mobile/__init__.py`**: export `SensorBase` alongside its concrete subclass `RangeBearingSensor`, so `roboticstoolbox.mobile.SensorBase` (used by `mobile-SLAM.rst`, and a reasonable thing to subclass for a custom sensor) actually resolves
- **`Dynamics.py`**: fix a stray extra `)` in `fdyn`'s docstring example (`torque_args=(qstar, P, D)) )`) — broke `sphinx_codeautolink`'s parser wherever `DynamicsMixin.fdyn` gets autodoc'd (`arm_dh`, `arm_erobot`, `arm_superclass`), accounting for 5 of the 9 warnings
- **`intro.rst`**: prefix the `DHRobot(...)` example's continuation lines with the proper pycon `...` prompt instead of leaving them unprefixed — codeautolink was only parsing the first line in isolation and seeing an unclosed `(`

Verified: full local Sphinx build goes from 9 warnings to 0. `tests/test_mobile.py` passes (17/17) after the `mobile/__init__.py` export change.

## Related issue

<!-- Fixes #123 / Closes #123 — if applicable -->

## Checklist

Only the first item below is checked automatically — the rest are a self-check for you before requesting review, nothing currently verifies them for you.

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`type: description`) — checked automatically, see the "Check PR title" status
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for this change, if applicable
- [x] New/changed code is type-hinted with modern syntax (`X | Y`, `list[X]`, not `Union`/`Optional`/`List`)
- [x] Docstrings updated (reST style: `:param:`, `:returns:`; type hints in the signature cover types now, `:type:`/`:rtype:` are rarely needed)
- [x] PR is as small/focused as practical — if it tackles several unrelated things, consider splitting it so each can be reviewed and accepted independently
- [x] No test files, data files, or notebooks specific to your own project — PyPI has strict package size limits, and RTB is already split into a toolbox and a data package. Notebooks, if of general interest, should have output cleared before committing.

<!-- Target branch is `main`. -->