### PR TITLE
ci: add Python 3.14 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        exclude:
-          - os: windows-latest
-            python-version: "3.13"
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         exclude:
           - os: windows-latest
             python-version: "3.13"


### PR DESCRIPTION
Thanks for contributing to RTB!

## Summary

Add `3.14` to `ci.yml`'s test matrix (`ubuntu-latest`, `windows-latest`, `macos-latest`).

Deliberately scoped to CI test coverage only — `pyproject.toml`'s version classifiers and the `cibuildwheel` wheel-build targets are a separate "officially support/publish for 3.14" decision, held pending this actually passing across all three OSes. Will follow up separately once that's confirmed.

## Related issue

<!-- Fixes #123 / Closes #123 — if applicable -->

## Checklist

Only the first item below is checked automatically — the rest are a self-check for you before requesting review, nothing currently verifies them for you.

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`type: description`) — checked automatically, see the "Check PR title" status
- [x] Tests pass locally (`pytest`)
- [ ] Added/updated tests for this change, if applicable
- [x] New/changed code is type-hinted with modern syntax (`X | Y`, `list[X]`, not `Union`/`Optional`/`List`)
- [x] Docstrings updated (reST style: `:param:`, `:returns:`; type hints in the signature cover types now, `:type:`/`:rtype:` are rarely needed)
- [x] PR is as small/focused as practical — if it tackles several unrelated things, consider splitting it so each can be reviewed and accepted independently
- [x] No test files, data files, or notebooks specific to your own project — PyPI has strict package size limits, and RTB is already split into a toolbox and a data package. Notebooks, if of general interest, should have output cleared before committing.

<!-- Target branch is `main`. -->