### PR TITLE
ci: re-add robot_descriptions caching, keyed by python-version this time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,24 @@ jobs:
       - name: Install package (core, no swift)
         run: pip install .[dev]
 
+      # Model tests (YuMi, Valkyrie, ...) load URDFs via the robot_descriptions
+      # package, which does NOT bundle the actual asset data -- on first use of
+      # a given model it lazily `git clone`s a large upstream asset repo
+      # straight into this cache dir. That clone is real network I/O and can
+      # be slow or occasionally flaky (timeout) on a cold runner. Caching the
+      # directory means only the first run after this lands pays that cost.
+      # Keyed by python-version too (not just OS) -- see the "Removed:
+      # robot_descriptions CI caching" tech-debt entry (git history,
+      # tech-debt.md as of commit f46b5c83^) for why a previous attempt at
+      # this (PR #530) didn't actually help: an OS-only key can't distinguish
+      # between the os x python-version matrix's parallel jobs. Bump "v2" to
+      # force a clean re-fetch if the cache ever ends up corrupted/stale.
+      - name: Cache robot_descriptions assets
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/robot_descriptions
+          key: robot-descriptions-v2-${{ runner.os }}-3.12
+
       - name: Verify compiled extensions built
         # Catches a silent build/import regression for _fknm_c/_frne_c --
         # without this, tests/test_fknm_fallback.py's C-vs-Python
@@ -82,6 +100,14 @@ jobs:
       - name: Install package
         run: pip install .[dev]
 
+      # See the "Cache robot_descriptions assets" step in test-core above --
+      # same reasoning, this job hits the same lazily-cloned model data.
+      - name: Cache robot_descriptions assets
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/robot_descriptions
+          key: robot-descriptions-v2-${{ runner.os }}-${{ matrix.python-version }}
+
       - name: Verify compiled extensions built
         # See the same step in test-core for why this matters.
         shell: bash
@@ -129,6 +155,14 @@ jobs:
       - name: Install package
         run: pip install .[dev]
 
+      # See the "Cache robot_descriptions assets" step in test-core above --
+      # same reasoning, this job hits the same lazily-cloned model data.
+      - name: Cache robot_descriptions assets
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/robot_descriptions
+          key: robot-descriptions-v2-${{ runner.os }}-3.12
+
       - name: Run coverage
         run: pytest tests/ --ignore=tests/test_blocks.py --cov=src/roboticstoolbox --cov-report=xml:coverage.xml -q
 
@@ -158,6 +192,14 @@ jobs:
           pip install .[docs]
           pip install sympy
           sudo apt-get install -y graphviz
+
+      # See the "Cache robot_descriptions assets" step in test-core above --
+      # intro.rst's YuMi runblock example loads via robot_descriptions too.
+      - name: Cache robot_descriptions assets
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/robot_descriptions
+          key: robot-descriptions-v2-${{ runner.os }}-3.12
 
       - name: Build docs
         # TODO: add -W once warning count reaches zero


### PR DESCRIPTION
Thanks for contributing to RTB!

## Summary

PR #530 added `actions/cache` steps for `~/.cache/robot_descriptions`, but they were removed in PR #536: `robot_descriptions` wasn't even a declared dependency at the time, so every run hit `ModuleNotFoundError` before any clone was attempted — the caching solved a problem that didn't exist yet, and had its own bug (cache key was OS-only, so it couldn't help across the `os x python-version` matrix's parallel jobs anyway).

That dependency gap is long fixed, and `robot_descriptions` is now genuinely exercised (YuMi, Valkyrie, UR3/5/10, Jaco, PR2, ...). Hit a concrete instance of the predicted failure mode directly: a real git-clone timeout in the `macos-latest`/3.12 job of PR #611's first CI run (unrelated to that PR's own change — just an ordinary transient network flake against `robot_descriptions`' upstream asset repos).

Re-adding caching with the corrected key (now includes `python-version`) to `test-core`, `test`, and `coverage` — and also `docs-build`, which wasn't covered by the original PR but genuinely needs it too: `intro.rst`'s YuMi example runs as a live `.. runblock::` during the Sphinx build.

## Related issue

<!-- Fixes #123 / Closes #123 — if applicable -->

## Checklist

Only the first item below is checked automatically — the rest are a self-check for you before requesting review, nothing currently verifies them for you.

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`type: description`) — checked automatically, see the "Check PR title" status
- [x] Tests pass locally (`pytest`)
- [ ] Added/updated tests for this change, if applicable
- [x] New/changed code is type-hinted with modern syntax (`X | Y`, `list[X]`, not `Union`/`Optional`/`List`)
- [x] Docstrings updated (reST style: `:param:`, `:returns:`; type hints in the signature cover types now, `:type:`/`:rtype:` are rarely needed)
- [x] PR is as small/focused as practical — if it tackles several unrelated things, consider splitting it so each can be reviewed and accepted independently
- [x] No test files, data files, or notebooks specific to your own project — PyPI has strict package size limits, and RTB is already split into a toolbox and a data package. Notebooks, if of general interest, should have output cleared before committing.

<!-- Target branch is `main`. -->