### PR TITLE
docs: point graphics-block docstrings at |GraphicsBlockOptions|

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -197,6 +197,7 @@ rst_epilog = """
 .. role:: raw-html(raw)
    :format: html
 .. |BlockOptions| replace:: :raw-html:`<a href="https://petercorke.github.io/bdsim/internals.html?highlight=block%20__init__#bdsim.Block.__init__">common Block options</a>`
+.. |GraphicsBlockOptions| replace:: :raw-html:`<a href="https://petercorke.github.io/bdsim/internals.html?highlight=graphicsblock%20__init__#bdsim.GraphicsBlock.__init__">common GraphicsBlock options</a>`
 """
 
 # -------- Suppress common noisy warnings ----------------------------------------#

--- a/src/roboticstoolbox/blocks/arm.py
+++ b/src/roboticstoolbox/blocks/arm.py
@@ -385,7 +385,7 @@ class ArmPlot(GraphicsBlock):
         :type q0: ndarray(N)
         :param backend: RTB backend name, defaults to 'pyplot'
         :type backend: str, optional
-        :param blockargs: |BlockOptions|
+        :param blockargs: |GraphicsBlockOptions|
         :type blockargs: dict
         """
         if robot is None:

--- a/src/roboticstoolbox/blocks/mobile.py
+++ b/src/roboticstoolbox/blocks/mobile.py
@@ -421,7 +421,7 @@ class VehiclePlot(GraphicsBlock):
         :type size: float or array_like, optional
         :param polyargs: arguments passed to :meth:`Animation.Polygon`
         :type polyargs: dict
-        :param blockargs: |BlockOptions|
+        :param blockargs: |GraphicsBlockOptions|
         :type blockargs: dict
 
         .. note::

--- a/src/roboticstoolbox/blocks/uav.py
+++ b/src/roboticstoolbox/blocks/uav.py
@@ -676,7 +676,7 @@ class MultiRotorPlot(GraphicsBlock):
         :type flapscale: float
         :param projection: 3D projection, one of: 'ortho' [default], 'perspective'
         :type projection: str
-        :param blockargs: |BlockOptions|
+        :param blockargs: |GraphicsBlockOptions|
         :type blockargs: dict
         """
         if model is None:


### PR DESCRIPTION
## Summary
- \`VehiclePlot\`, \`ArmPlot\`, and \`MultiRotorPlot\` are all \`GraphicsBlock\` subclasses (bdsim), so their \`**blockargs\` now also flows through \`GraphicsBlock\`'s own kwargs (\`movie\`, \`timestamp\`, \`timestamp_fmt\`, and now \`watch\` -- see [petercorke/bdsim#75](https://github.com/petercorke/bdsim/pull/75)) in addition to \`Block\`'s. Their \`blockargs\` docstring line pointed only at \`Block.__init__\` via \`|BlockOptions|\`, silently omitting the graphics-level options.
- Added \`|GraphicsBlockOptions|\` to \`conf.py\`, mirroring the existing \`|BlockOptions|\` pattern (same raw-html substitution, redefined per-repo since there's no intersphinx mapping to bdsim's docs today), and pointed these three blocks at it instead.

Companion PR to bdsim#75, which promotes \`watch\` from a \`Scope\`-only parameter to a shared \`GraphicsBlock.__init__\` parameter -- these three RTB blocks now genuinely accept \`watch=True\` once that lands, not just document-in-theory.

## Test plan
- [x] \`pytest tests/ -k "block or bdsim or Vehicle or ArmPlot or MultiRotor"\` -- 24 passed, 6 pre-existing skips
- [x] Confirmed \`ArmPlot(..., watch=True)\` constructs and sets \`self.watch = True\` correctly against the local bdsim#75 branch