### PR TITLE
fix: forward name/base/tool/etc through Robot's clone-from-Robot constructor

### DIFF
--- a/src/roboticstoolbox/robot/Robot.py
+++ b/src/roboticstoolbox/robot/Robot.py
@@ -49,6 +49,13 @@ from roboticstoolbox.tools.data import rtb_path_to_datafile
 # A generic type variable representing any subclass of BaseLink
 LinkType = TypeVar("LinkType", bound=BaseLink)
 
+# Shared default objects for Robot.__init__'s gravity/keywords parameters,
+# identity-compared in the clone-from-Robot branch to detect "caller didn't
+# override this" (a plain equality/falsy check can't tell a genuine [0, 0,
+# -9.81] override apart from the unset default).
+_GRAVITY_DEFAULT: list[float] = [0, 0, -9.81]
+_KEYWORDS_DEFAULT: list[str] = []
+
 
 # ==================================================================================== #
 # ================= Robot Class ====================================================== #
@@ -67,8 +74,8 @@ class Robot(BaseRobot[Link], RobotKinematicsMixin):
         comment: str = "",
         base: NDArray | SE3 | None = None,
         tool: NDArray | SE3 | None = None,
-        gravity: ArrayLike = [0, 0, -9.81],
-        keywords: list[str] | tuple[str, ...] = [],
+        gravity: ArrayLike = _GRAVITY_DEFAULT,
+        keywords: list[str] | tuple[str, ...] = _KEYWORDS_DEFAULT,
         symbolic: bool = False,
         configs: dict[str, NDArray] | None = None,
         check_jindex: bool = True,
@@ -98,7 +105,24 @@ class Robot(BaseRobot[Link], RobotKinematicsMixin):
                     link._parent_name = link.parent.name
                     link._parent = None
 
-            super().__init__(links, gripper_links=gripper_links)
+            # Clone the source robot's own attributes for anything the
+            # caller didn't explicitly override (name="" / base=None /
+            # etc. are the "not given" markers matching this signature's
+            # own defaults above).
+            super().__init__(
+                links,
+                gripper_links=gripper_links,
+                name=name or arg.name,
+                manufacturer=manufacturer or arg.manufacturer,
+                comment=comment or arg.comment,
+                base=base if base is not None else arg.base,
+                tool=tool if tool is not None else arg.tool,
+                gravity=gravity if gravity is not _GRAVITY_DEFAULT else arg.gravity,
+                keywords=keywords if keywords is not _KEYWORDS_DEFAULT else arg.keywords,
+                symbolic=symbolic,
+                configs=configs if configs is not None else arg.configs,
+                check_jindex=check_jindex,
+            )
 
             for i, gripper in enumerate(self.grippers):
                 gripper.tool = arg.grippers[i].tool.copy()

--- a/tests/test_Robot.py
+++ b/tests/test_Robot.py
@@ -592,6 +592,37 @@ class TestRobot(unittest.TestCase):
 
         self.assertEqual(r.n, r2.n)
 
+    def test_copy_init_inherits_source_attributes(self):
+        # Cloning via Robot(other_robot) with no overrides should carry
+        # over the source robot's own name/base/tool/etc, not silently
+        # reset them to the class defaults.
+        from spatialmath import SE3
+
+        r = rtb.models.Panda()
+
+        r2 = rtb.Robot(r)
+
+        self.assertEqual(r2.name, r.name)
+        self.assertEqual(r2.manufacturer, r.manufacturer)
+        nt.assert_array_almost_equal(r2.base.A, r.base.A)
+        nt.assert_array_almost_equal(r2.tool.A, r.tool.A)
+        nt.assert_array_almost_equal(r2.gravity, r.gravity)
+
+    def test_copy_init_overrides_attributes(self):
+        # Cloning via Robot(other_robot, name=..., base=..., tool=...)
+        # should apply the overrides rather than dropping them.
+        from spatialmath import SE3
+
+        r = rtb.models.Panda()
+        base = SE3(0.1, 0.2, 0.3)
+        tool = SE3(0, 0, 0.05)
+
+        r2 = rtb.Robot(r, name="panda2", base=base, tool=tool)
+
+        self.assertEqual(r2.name, "panda2")
+        nt.assert_array_almost_equal(r2.base.A, base.A)
+        nt.assert_array_almost_equal(r2.tool.A, tool.A)
+
     def test_init2(self):
         r = rtb.Robot(rtb.ETS(rtb.ET.Ry(qlim=[-1, 1])))
 


### PR DESCRIPTION
## Summary

`Robot.__init__` has two construction paths. When constructing from another
`Robot`/`ERobot` instance (the "clone" path used by e.g.
`ERobot(leg, name='leg0', base=SE3(...))`), it copied the links but called
`super().__init__(links, gripper_links=gripper_links)` without forwarding
any of the other constructor kwargs. `name`, `manufacturer`, `comment`,
`base`, `tool`, `gravity`, `keywords`, and `configs` were all silently
dropped -- whether or not the caller passed them -- and fell back to
`BaseRobot`'s bare defaults (`""`, identity, etc).

Found while debugging RVC3-python's `walking.py`, which builds 4 leg robots
via `ERobot(leg, name=f'leg{i}', base=SE3(...))`: all 4 legs ended up with
identity base, since the base kwarg was ignored.

- Forward every attribute through the clone branch, falling back to the
  *source* robot's own value when the caller didn't override it -- so
  `Robot(other, ...)` behaves like a real clone-with-overrides rather than
  resetting most of the robot's identity to blank/default (this also fixes
  a related silent bug: cloning with **no** kwargs at all still lost
  `name`/`manufacturer`/etc, e.g. `Robot(rtb.models.Panda())` produced a
  robot named `""` instead of `"panda"`).
- `symbolic` and `check_jindex` are intentionally left out of the fallback:
  `symbolic` is auto-detected from the (correctly copied) link parameters
  regardless of the flag, and `check_jindex` is a one-time constructor
  validation toggle, not part of a robot's identity.

## Test plan

- [x] Added `test_copy_init_inherits_source_attributes` and
      `test_copy_init_overrides_attributes` to `tests/test_Robot.py`
- [x] Full suite: `pytest tests/` -- 721 passed, 15 skipped, no regressions
- [x] Reproduced the `walking.py` leg-cloning pattern manually -- all 4
      legs now get distinct, correct `base` transforms and names

🤖 Generated with [Claude Code](https://claude.com/claude-code)