### PR TITLE
fix: Robot._to_dict() uses set_alpha(), deprecated by spatialgeometry

### DIFF
--- a/src/roboticstoolbox/robot/Robot.py
+++ b/src/roboticstoolbox/robot/Robot.py
@@ -160,11 +160,11 @@ class Robot(BaseRobot[Link], RobotKinematicsMixin):
         for link in self.links:
             if robot_alpha > 0:
                 for gi in link.geometry:
-                    gi.set_alpha(robot_alpha)
+                    gi.opacity = robot_alpha
                     ob.append(gi.to_dict())
             if collision_alpha > 0:
                 for gi in link.collision:
-                    gi.set_alpha(collision_alpha)
+                    gi.opacity = collision_alpha
                     ob.append(gi.to_dict())
 
         # Do the grippers now
@@ -172,11 +172,11 @@ class Robot(BaseRobot[Link], RobotKinematicsMixin):
             for link in gripper.links:
                 if robot_alpha > 0:
                     for gi in link.geometry:
-                        gi.set_alpha(robot_alpha)
+                        gi.opacity = robot_alpha
                         ob.append(gi.to_dict())
                 if collision_alpha > 0:
                     for gi in link.collision:
-                        gi.set_alpha(collision_alpha)
+                        gi.opacity = collision_alpha
                         ob.append(gi.to_dict())
 
         # for o in ob:


### PR DESCRIPTION
## Summary

`spatialgeometry` deprecated `Shape.set_alpha()` in favour of an `opacity` property (functionally identical -- `set_alpha` just does `self.opacity = alpha` internally -- but emits a `FutureWarning` on every call now). `Robot._to_dict()` calls `set_alpha()` on every link/gripper geometry and collision shape, so any `env.add_robot(robot)` in Swift triggers the warning. Switched to the `opacity` property directly.

## Test plan

- [x] `panda._to_dict(robot_alpha=0.5, collision_alpha=0.3)` under `warnings.simplefilter("error")`: no warnings raised, `opacity` correctly set on the returned dicts
- [x] `tests/test_Robot.py` + `tests/test_ERobot.py`: 53 passed, 5 skipped (unrelated), one pre-existing unrelated warning (`_propogate_scene_tree`, a different deprecated call elsewhere in the test)
