### PR TITLE
docs: update Swift RRMC example to the AssemblyHandle API

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,24 +310,29 @@ env = swift.Swift()
 env.launch(realtime=True)
 
 panda = rtb.models.Panda()
-panda.q = panda.qr
+handle = env.add(panda)
+handle.q = panda.qr
 
-Tep = panda.fkine(panda.q) * sm.SE3.Trans(0.2, 0.2, 0.45)
+Tep = panda.fkine(handle.q) * sm.SE3.Trans(0.2, 0.2, 0.45)
 
 arrived = False
-env.add(panda)
 
 dt = 0.05
 
 while not arrived:
 
-    v, arrived = rtb.p_servo(panda.fkine(panda.q), Tep, 1)
-    panda.qd = np.linalg.pinv(panda.jacobe(panda.q)) @ v
+    v, arrived = rtb.p_servo(panda.fkine(handle.q), Tep, 1)
+    handle.qd = np.linalg.pinv(panda.jacobe(handle.q)) @ v
     env.step(dt)
 
 # Uncomment to stop the browser tab from closing
 # env.hold()
 ```
+
+`env.add(panda)` returns a handle owning this instance's live joint state --
+drive the simulation via `handle.q`/`handle.qd`, not `panda.q`/`panda.qd`
+directly. `panda` itself stays a plain, shareable kinematic model, so the
+same `panda` object can back several independent handles/instances at once.
 
 <p align="center">
 	<img src="./docs/figs/panda3.gif">

--- a/examples/RRMC_swift.py
+++ b/examples/RRMC_swift.py
@@ -12,18 +12,18 @@ env = swift.Swift()
 env.launch(realtime=True)
 
 panda = rp.models.Panda()
-panda.q = panda.qr
+handle = env.add(panda)
+handle.q = panda.qr
 
-Tep = panda.fkine(panda.q) * sm.SE3.Tx(0.2) * sm.SE3.Ty(0.2) * sm.SE3.Tz(0.45)
+Tep = panda.fkine(handle.q) * sm.SE3.Tx(0.2) * sm.SE3.Ty(0.2) * sm.SE3.Tz(0.45)
 
 arrived = False
-env.add(panda)
 
 dt = 0.05
 
 while not arrived:
-    v, arrived = rp.p_servo(panda.fkine(panda.q), Tep, 1)
-    panda.qd = np.linalg.pinv(panda.jacobe(panda.q)) @ v
+    v, arrived = rp.p_servo(panda.fkine(handle.q), Tep, 1)
+    handle.qd = np.linalg.pinv(panda.jacobe(handle.q)) @ v
     env.step(dt)
 
 # Uncomment to stop the browser tab from closing


### PR DESCRIPTION
## Summary

The README's resolved-rate motion control example (and its standalone copy, `examples/RRMC_swift.py`) predates Swift 2.0's `AssemblyHandle` refactor: `env.add(panda)` now returns a handle owning the live `q`/`qd` state, and driving the simulation by mutating `panda.q`/`panda.qd` directly is deprecated.

Worse than a deprecation warning, though: a control loop that reads `panda.q` back mid-loop (as both these examples do) reads a permanently stale value by default -- Swift doesn't write back into the robot object unless the deprecated path is explicitly engaged (see companion Swift PR jhavl/swift#129). The robot never converges.

Updated both to capture and drive the handle instead -- the currently-correct way to write this example regardless of that Swift-side fix.

`examples/RRMC.py` (PyPlot backend, not Swift) is unaffected -- untouched. `examples/branched_robot.py` uses the same deprecated `r.qd[...] = ...` legacy-mutation style but is a functional non-issue once jhavl/swift#129 lands; left as-is rather than expanding scope here.

## Test plan

- [x] Ran the updated example headlessly under `warnings.simplefilter("error")`: converges in 43 steps, zero warnings, `panda` itself stays untouched (confirming it's a genuinely plain, shareable model)
