### PR TITLE
fix: honour flipped standard-DH joints in DHLink.A

### DIFF
--- a/src/roboticstoolbox/robot/DHLink.py
+++ b/src/roboticstoolbox/robot/DHLink.py
@@ -616,7 +616,7 @@ class DHLink(Link):
         sa = _sin(self.alpha)
         ca = _cos(self.alpha)
 
-        if self.ets[-1].isflip:
+        if self.v is not None and self.v.isflip:
             q = -q + self.offset
         else:
             q = q + self.offset

--- a/tests/test_DHRobot.py
+++ b/tests/test_DHRobot.py
@@ -168,6 +168,33 @@ class TestDHRobot(unittest.TestCase):
         nt.assert_array_almost_equal(r0.qlim, ans)
         nt.assert_array_almost_equal(r1.qlim, np.c_[qlim])
 
+    def test_A_flip_standard_dh(self):
+        q = 0.3
+
+        flipped = rp.RevoluteDH(
+            d=0.2, a=0.3, alpha=0.4, offset=0.1, flip=True
+        )
+        normal = rp.RevoluteDH(
+            d=0.2, a=0.3, alpha=0.4, offset=0.1
+        )
+
+        nt.assert_array_almost_equal(
+            flipped.A(q).A,
+            normal.A(-q).A,
+        )
+
+        flipped = rp.PrismaticDH(
+            theta=0.2, a=0.3, alpha=0.4, offset=0.1, flip=True
+        )
+        normal = rp.PrismaticDH(
+            theta=0.2, a=0.3, alpha=0.4, offset=0.1
+        )
+
+        nt.assert_array_almost_equal(
+            flipped.A(q).A,
+            normal.A(-q).A,
+        )
+
     def test_fkine(self):
         l0 = rp.PrismaticDH()
         l1 = rp.RevoluteDH()


### PR DESCRIPTION
Fixes #563

## Summary

Use the variable joint ET (`self.v`) when applying `flip` in `DHLink.A()` instead of assuming the last ET in the sequence is the joint ET.

For standard DH links, constant transforms such as `d`, `a`, or `alpha` can follow the joint ET, so `self.ets[-1].isflip` may inspect the wrong ET.

## Tests

Added regression coverage for both revolute and prismatic standard-DH links with `flip=True`.

- `python -m pytest tests/test_DHRobot.py -k test_A_flip_standard_dh -q`
  - 1 passed
- `python -m pytest tests/test_DHRobot.py -q`
  - 71 passed, 1 skipped