### PR TITLE
fix(swift): use Slider/Label/Button's label kwarg, not deprecated desc

### DIFF
--- a/examples/teach_swift.py
+++ b/examples/teach_swift.py
@@ -39,7 +39,7 @@ for link in panda.links:
                 max=np.round(np.rad2deg(link.qlim[1]), 2),
                 step=1,
                 value=np.round(np.rad2deg(panda.q[j]), 2),
-                desc="Panda Joint " + str(j),
+                label="Panda Joint " + str(j),
                 unit="&#176;",
             )
         )

--- a/src/roboticstoolbox/demo/tripleangledemo.py
+++ b/src/roboticstoolbox/demo/tripleangledemo.py
@@ -108,11 +108,11 @@ def demo(test: bool = False):
         update_gimbals(float(x), 3)
 
     r_one = swift.Slider(
-        set_one, min=-180, max=180, step=1, value=0, desc="Outer gimbal", unit="&#176;"
+        set_one, min=-180, max=180, step=1, value=0, label="Outer gimbal", unit="&#176;"
     )
 
     r_two = swift.Slider(
-        set_two, min=-180, max=180, step=1, value=0, desc="Middle gimbal", unit="&#176;"
+        set_two, min=-180, max=180, step=1, value=0, label="Middle gimbal", unit="&#176;"
     )
 
     r_three = swift.Slider(
@@ -121,24 +121,24 @@ def demo(test: bool = False):
         max=180,
         step=1,
         value=0,
-        desc="Inner gimbal",
+        label="Inner gimbal",
         unit="&#176;",
     )
 
     # buttons to set a 3-angle sequence
     ZYX_button = swift.Button(
-        lambda x: change_sequence("ZYX"), desc="ZYX (roll-pitch-yaw angles)"
+        lambda x: change_sequence("ZYX"), label="ZYX (roll-pitch-yaw angles)"
     )
 
     XYZ_button = swift.Button(
-        lambda x: change_sequence("XYZ"), desc="XYZ (roll-pitch-yaw angles)"
+        lambda x: change_sequence("XYZ"), label="XYZ (roll-pitch-yaw angles)"
     )
 
     ZYZ_button = swift.Button(
-        lambda x: change_sequence("ZYZ"), desc="ZYZ (Euler angles)"
+        lambda x: change_sequence("ZYZ"), label="ZYZ (Euler angles)"
     )
 
-    swift.Button(lambda x: set("ZYX"), desc="Set to Zero")
+    swift.Button(lambda x: set("ZYX"), label="Set to Zero")
 
     # button to reset joint angles
     def reset(e):
@@ -147,7 +147,7 @@ def demo(test: bool = False):
         r_three.value = 0
         # env.step(0)
 
-    zero_button = swift.Button(reset, desc="Set to Zero")
+    zero_button = swift.Button(reset, label="Set to Zero")
 
     def update_all_sliders():
         update_gimbals(float(r_one.value), 1)
@@ -184,7 +184,7 @@ def demo(test: bool = False):
 
     ring3_axis = swift.Radio(lambda x: angle(x, 2), options=["X", "Y", "Z"], checked=0)
 
-    label = swift.Label(desc="Triple angle")
+    label = swift.Label(label="Triple angle")
 
     # def chekked(e, el):
     #     nlabel = "s: "
@@ -204,7 +204,7 @@ def demo(test: bool = False):
     #     if e[3]:
     #         el.value = 1
 
-    #     label.desc = nlabel
+    #     label.label = nlabel
 
     env.add(label)
     env.add(r_one)

--- a/src/roboticstoolbox/demo/twistdemo.py
+++ b/src/roboticstoolbox/demo/twistdemo.py
@@ -94,7 +94,7 @@ def demo(test: bool = False):
         max=1,
         step=0.01,
         value=0,
-        desc="x position",
+        label="x position",
     )
 
     twist_y = swift.Slider(
@@ -103,7 +103,7 @@ def demo(test: bool = False):
         max=1,
         step=0.01,
         value=0,
-        desc="y position",
+        label="y position",
     )
 
     twist_rollangle = swift.Slider(
@@ -112,7 +112,7 @@ def demo(test: bool = False):
         max=180,
         step=1,
         value=0,
-        desc="roll angle (rx)",
+        label="roll angle (rx)",
         unit="&#176;",
     )
 
@@ -122,7 +122,7 @@ def demo(test: bool = False):
         max=180,
         step=1,
         value=0,
-        desc="pitch angle (ry)",
+        label="pitch angle (ry)",
         unit="&#176;",
     )
 
@@ -132,18 +132,18 @@ def demo(test: bool = False):
         max=1,
         step=0.02,
         value=0,
-        desc="screw pitch",
+        label="screw pitch",
     )
 
     twist_theta = swift.Slider(
-        update_plane, min=0, max=10, step=0.02, value=0, desc="Twist rotation"
+        update_plane, min=0, max=10, step=0.02, value=0, label="Twist rotation"
     )
 
-    button = swift.Button(reset_twist, desc="Set to Zero")
-    quit = swift.Button(lambda x: sys.exit(0), desc="Quit")
+    button = swift.Button(reset_twist, label="Set to Zero")
+    quit = swift.Button(lambda x: sys.exit(0), label="Quit")
 
-    label1 = swift.Label(desc="Twist parameters")
-    label2 = swift.Label(desc="Twist application")
+    label1 = swift.Label(label="Twist parameters")
+    label2 = swift.Label(label="Twist application")
 
     env.add(label1)
     env.add(twist_x)


### PR DESCRIPTION
## Summary
- `swift-sim` renamed the `desc` constructor kwarg/property to `label` on all `SwiftElement` subclasses ([jhavl/swift#135](https://github.com/jhavl/swift/pull/135)) — `desc` still works via a deprecation shim, but this updates RTB's own usages to the new name rather than carry the warning forward
- Fixed in `src/roboticstoolbox/demo/tripleangledemo.py`, `src/roboticstoolbox/demo/twistdemo.py`, and `examples/teach_swift.py`

## Test plan
- [x] `pytest tests/test_demo.py` — covers `tripleangledemo`/`twistdemo` construction, no regressions
- [x] Verified against a local combined build of swift's `feat/element-desc-to-label` + `feat/label-compact` branches (both still open, unmerged) — no `DeprecationWarning`s raised

🤖 Generated with [Claude Code](https://claude.com/claude-code)