### PR TITLE
fix(plot): use matplotlib colormaps registry instead of removed cm.get_cmap

### DIFF
--- a/src/roboticstoolbox/mobile/DistanceTransformPlanner.py
+++ b/src/roboticstoolbox/mobile/DistanceTransformPlanner.py
@@ -9,7 +9,7 @@ from spatialmath.pose2d import SE2
 from spatialmath import base
 from scipy.ndimage import *
 import matplotlib.pyplot as plt
-from matplotlib import cm
+from matplotlib import colormaps
 from roboticstoolbox.mobile.PlannerBase import PlannerBase
 
 
@@ -324,9 +324,7 @@ def distancexform(occgrid, goal, metric="cityblock", animate=False, summary=Fals
                 plt.ylabel("y")
                 ax = plt.gca()
                 plt.pause(0.001)
-                cmap = cm.get_cmap("gray")
-                cmap.set_bad("red")
-                cmap.set_over("white")
+                cmap = colormaps.get_cmap("gray").with_extremes(bad="red", over="white")
                 h = plt.imshow(display, cmap=cmap)
                 plt.colorbar(label="distance")
             else:

--- a/src/roboticstoolbox/robot/RobotPlottingMPL.py
+++ b/src/roboticstoolbox/robot/RobotPlottingMPL.py
@@ -62,12 +62,12 @@ class RobotPlottingMPLMixin:
 
         """
 
-        from matplotlib import cm, colors
+        from matplotlib import colormaps, colors
 
-        if isinstance(linkcolors, list) and len(linkcolors) == self.n:  # type: ignore[attr-defined]  # pragma: nocover
+        if isinstance(linkcolors, list) and len(linkcolors) == self.n:  # type: ignore[attr-defined]
             return colors.ListedColormap(linkcolors)
-        else:  # pragma: nocover
-            return cm.get_cmap(linkcolors, 6)  # type: ignore[arg-type]
+        else:
+            return colormaps.get_cmap(linkcolors).resampled(6)
 
     # ------------------------------------------------------------------
     # Ellipse creation

--- a/tests/test_backend_capabilities.py
+++ b/tests/test_backend_capabilities.py
@@ -112,6 +112,20 @@ class TestMPLMixinOnRobot(unittest.TestCase):
         robot = self._make_robot()
         self.assertTrue(hasattr(robot, "linkcolormap"))
 
+    def test_linkcolormap_from_name(self):
+        # Regression test: linkcolormap() used matplotlib.cm.get_cmap(),
+        # removed in matplotlib 3.9, so any named colormap raised
+        # AttributeError instead of returning a 6-entry colormap.
+        robot = self._make_robot()
+        cmap = robot.linkcolormap("inferno")
+        self.assertEqual(cmap.N, 6)
+
+    def test_linkcolormap_from_list(self):
+        robot = self._make_robot()
+        colors = ["red", "g", (0, 0.5, 0), "#0f8040", "yellow", "cyan"]
+        cmap = robot.linkcolormap(colors)
+        self.assertEqual(cmap.N, len(colors))
+
     def test_mixin_present_in_mro(self):
         import roboticstoolbox as rtb
         from roboticstoolbox.robot.RobotPlottingMPL import RobotPlottingMPLMixin

--- a/tests/test_distance_transform_plot.py
+++ b/tests/test_distance_transform_plot.py
@@ -25,3 +25,17 @@ def test_distance_transform_next_before_plan_raises():
 
     with pytest.raises(ValueError, match="No distance map computed"):
         planner.next((0, 0))
+
+
+def test_distancexform_animate():
+    # Regression test: the animate path used matplotlib.cm.get_cmap(),
+    # removed in matplotlib 3.9, so plan(animate=True) raised
+    # AttributeError before computing the distance map.
+    floorplan = np.zeros((10, 10), dtype=int)
+    floorplan[4:7, 4:7] = 1
+
+    planner = rtb.DistanceTransformPlanner(floorplan, inflate=1)
+    planner.plan((8, 8), animate=True)
+
+    assert planner.distancemap is not None
+    plt.close("all")


### PR DESCRIPTION
## Summary

`matplotlib.cm.get_cmap` was deprecated in matplotlib 3.7 and removed in 3.9. Two call sites still used it, so both raised `AttributeError: module 'matplotlib.cm' has no attribute 'get_cmap'` on any current matplotlib (`matplotlib` is unpinned in `pyproject.toml`):

- `RobotPlottingMPL.linkcolormap(name)` for any named colormap - a public API whose own docstring `runblock` calls `robot.linkcolormap("inferno")`
- `DistanceTransformPlanner.plan(animate=True)`, which failed before computing the distance map

Both are switched to the `colormaps` registry, with `resampled(6)` replacing the old `lut` argument. `set_bad`/`set_over` in the revived animate path are folded into `with_extremes` so executing it does not introduce new `PendingDeprecationWarning`s.

Neither path was reachable from the test suite - one sat behind `# pragma: nocover`, the other only runs under `animate=True` - which is why the earlier migration of `PlannerBase.py` to `mpl.colormaps` missed them. Those two now-covered pragmas are dropped.

## Related issue

None - found while checking an unrelated colorbar report, not tied to an existing issue.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`type: description`) — checked automatically, see the "Check PR title" status
- [x] Tests pass locally (`pytest`) — 632 passed, 72 skipped. The 4 `test_bin.py` failures also occur on pristine `main` here (missing `ipython` extra) and are unrelated.
- [x] Added/updated tests for this change, if applicable — regression tests for both paths; with the source change reverted they fail with the `AttributeError` above.
- [x] New/changed code is type-hinted with modern syntax (`X | Y`, `list[X]`, not `Union`/`Optional`/`List`) — no signatures added or changed.
- [x] Docstrings updated (reST style: `:param:`, `:returns:`; type hints in the signature cover types now, `:type:`/`:rtype:` are rarely needed) — no public API change.
- [x] PR is as small/focused as practical — one defect, two call sites of the same removed API.
- [x] No test files, data files, or notebooks specific to your own project
