### PR TITLE
fix: track swift's SwiftElement.py -> Elements.py rename

### DIFF
--- a/src/roboticstoolbox/backends/swift/__init__.py
+++ b/src/roboticstoolbox/backends/swift/__init__.py
@@ -1,5 +1,5 @@
 from swift.SwiftRoute import SwiftServer, SwiftSocket, start_servers
-from swift.SwiftElement import (
+from swift.Elements import (
     SwiftElement,
     Slider,
     Select,


### PR DESCRIPTION
## Summary
- swift (jhavl/swift) is renaming `src/swift/SwiftElement.py` -> `Elements.py`, to avoid a module/class name collision that was confusing mypy (the file and the `SwiftElement` class inside it shared a name, and the class is re-exported at swift's package top level) -- see [jhavl/swift#141](https://github.com/jhavl/swift/pull/141).
- `roboticstoolbox/backends/swift/__init__.py` imports directly from the submodule path (`from swift.SwiftElement import ...`) rather than from swift's own top-level re-exports, so it needs the matching one-line fix to keep working once that rename ships in a released `swift-sim` version.
- Not urgent -- nothing's broken yet, since swift's rename hasn't merged/released. This just keeps the two repos in sync before it does.

## Test plan
- [x] Loaded `backends/swift/__init__.py` standalone (via `importlib`) against a local swift checkout with the rename already applied -- resolves `Swift`, `Slider`, `SwiftElement`, etc. correctly from `swift.Elements`