### PR TITLE
fix: pin spatialgeometry/swift-sim to their real published versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,5 @@
 # Run tests, coverage, and build docs across all supported platforms
 # Triggers on pushes/PRs to main.
-#
-# spatialgeometry and swift-sim are installed from GitHub HEAD because the
-# current PyPI releases were compiled against NumPy 1.x and crash under 2.x.
-# Once numpy-2-compatible releases are published, remove those two steps and
-# use plain `pip install .[dev]`.
 
 name: CI
 
@@ -91,14 +86,8 @@ jobs:
           "TEMP=C:\T" >> $env:GITHUB_ENV
           "TMP=C:\T"  >> $env:GITHUB_ENV
 
-      - name: Install spatialgeometry + swift from source (NumPy 2 compatible)
-        run: |
-            pip install "websockets<11"
-            pip install git+https://github.com/jhavl/spatialgeometry.git@future
-            pip install git+https://github.com/jhavl/swift.git@future
-
       - name: Install package
-        run: pip install .[dev]
+        run: pip install .[dev,swift]
 
       # See the "Cache robot_descriptions assets" step in test-core above --
       # same reasoning, this job hits the same lazily-cloned model data.
@@ -146,14 +135,8 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Install spatialgeometry + swift from source (NumPy 2 compatible)
-        run: |
-          pip install "websockets<11"
-          pip install git+https://github.com/jhavl/spatialgeometry.git@future
-          pip install git+https://github.com/jhavl/swift.git@future
-
       - name: Install package
-        run: pip install .[dev]
+        run: pip install .[dev,swift]
 
       # See the "Cache robot_descriptions assets" step in test-core above --
       # same reasoning, this job hits the same lazily-cloned model data.
@@ -180,12 +163,6 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-
-      - name: Install spatialgeometry + swift from source (NumPy 2 compatible)
-        run: |
-          pip install "websockets<11"
-          pip install git+https://github.com/jhavl/spatialgeometry.git@future
-          pip install git+https://github.com/jhavl/swift.git@future
 
       - name: Install docs dependencies
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,7 @@ authors = [
 dependencies = [
     "numpy",
     "spatialmath-python>=1.1.16",
-    # Pinned to a commit on SG's unreleased main (1.4 draft) -- Link.py's
-    # SceneGroup(initlist) call requires the API there. Switch to a normal
-    # ">=1.4.0" constraint once spatialgeometry actually cuts that release.
-    "spatialgeometry @ git+https://github.com/jhavl/spatialgeometry.git@ce69b8bbe23ec79c0c395e007725512081808487",
+    "spatialgeometry>=1.4.0",
     "pgraph-python",
     "scipy",
     "matplotlib",
@@ -74,7 +71,7 @@ repository = "https://github.com/petercorke/robotics-toolbox-python"
 
 [project.optional-dependencies]
 
-swift = ["swift-sim>=1.0.0", "websockets"]
+swift = ["swift-sim>=2.0.0", "websockets"]
 
 collision = ["coal; sys_platform != 'win32'", "trimesh"]
 
@@ -83,7 +80,7 @@ qp = ["qpsolvers", "quadprog"]
 tool = ["ipython", "pygments"]
 
 all = [
-    "swift-sim>=1.0.0",
+    "swift-sim>=2.0.0",
     "websockets",
     "qpsolvers",
     "quadprog",


### PR DESCRIPTION
## Summary

spatialgeometry 1.4.0 and swift-sim 2.0.0 are now real, numpy-2-compatible PyPI releases, so the CI git-source workarounds are no longer needed.

- `pyproject.toml`: replace spatialgeometry's git-SHA pin with a normal `>=1.4.0` constraint; bump swift-sim's pin from `>=1.0.0` to `>=2.0.0` (both the `swift` and `all` extras).
- `ci.yml`: remove all three "install spatialgeometry + swift from source" workaround steps (including the now-unnecessary `websockets<11` pin -- swift's own `pyproject.toml` has no upper bound), and the stale header comment describing the workaround. The `test`/`coverage` jobs now pull `swift-sim` via the existing `swift` extra (`.[dev,swift]`) instead of a separate git install.

This also fixes the root cause behind #621/#622 currently failing CI: they use swift's new `label=`/`teach()` API, but CI was installing swift from a now-stale `future` branch ref that predates those changes on `main`.

## Test plan
- [x] Confirmed no other file references the old git-SHA pin or `@future` branch installs
- [ ] CI on this PR should now install real `spatialgeometry>=1.4.0` / `swift-sim>=2.0.0` from PyPI