### PR TITLE
fix: compute accel_x with analytical Jacobian derivative

### DIFF
--- a/src/roboticstoolbox/robot/Dynamics.py
+++ b/src/roboticstoolbox/robot/Dynamics.py
@@ -1256,21 +1256,23 @@ class DynamicsMixin:
         :returns: Operational space accelerations of the end-effector
         :rtype: ndarray(6,)
 
-        ``xdd = accel_x(q, qd, wrench)`` is the operational space acceleration
+        ``xdd = accel_x(q, xd, wrench)`` is the operational space acceleration
         due to ``wrench`` applied to the end-effector of a robot in joint
-        configuration ``q`` and joint velocity ``qd``.
+        configuration ``q`` and operational space velocity ``xd``.
 
         .. math::
 
-            \ddot{x} = \mathbf{J}(q) \mathbf{M}(q)^{-1} \left(
-                \mathbf{J}(q)^T w - \mathbf{C}(q)\dot{q} - \mathbf{g}(q)
+            \ddot{x} = \dot{\mathbf{J}}_a(q, \dot{q})\dot{q}
+                + \mathbf{J}_a(q) \mathbf{M}(q)^{-1} \left(
+                    \mathbf{J}_a(q)^T w - \mathbf{C}(q)\dot{q}
+                    - \mathbf{g}(q)
                 \right)
 
         **Trajectory operation**
 
-        If `q`, `qd`, torque are matrices (m,n) then ``qdd`` is a matrix (m,n)
-        where each row is the acceleration corresponding to the equivalent rows
-        of q, qd, wrench.
+        If ``q`` is a matrix (m,n), and ``xd`` and ``wrench`` are matrices
+        (m,6), then ``xdd`` is a matrix (m,6) where each row is the acceleration
+        corresponding to the equivalent rows of ``q``, ``xd``, and ``wrench``.
 
         .. rubric:: Notes
 
@@ -1294,7 +1296,7 @@ class DynamicsMixin:
         if q.shape[1] != 6:
             pinv = True
 
-        xdd = np.zeros((q.shape[0], self.n))
+        xdd = np.zeros((q.shape[0], 6))
 
         for k, (qk, xdk, wk) in enumerate(zip(q, xd, w)):
             Ja = self.jacob0_analytical(qk, representation=representation)
@@ -1322,16 +1324,10 @@ class DynamicsMixin:
 
             # xd = Ja qd
             # xdd = Jad qd + Ja qdd
-            #
-            # Ja = T J
-            # Jad = Td J + T Jd
-            # assume Td = 0, not sure how valid that is
-
-            # need Jacobian dot
             qdk = Ji @ xdk
-            Jd = self.jacob0_dot(qk, qdk, J0=Ja)
+            Jad = self.jacob0_dot(qk, qdk, representation=representation)
 
-            xdd[k, :] = T @ (Jd @ qdk + J @ qdd)
+            xdd[k, :] = Jad @ qdk + Ja @ qdd
 
         if q.shape[0] == 1:
             return xdd[0, :]

--- a/tests/test_DHRobot.py
+++ b/tests/test_DHRobot.py
@@ -1138,6 +1138,35 @@ class TestDHRobot(unittest.TestCase):
         nt.assert_array_almost_equal(qdd1[0, :], res, decimal=4)
         nt.assert_array_almost_equal(qdd1[1, :], res, decimal=4)
 
+    def test_accel_x(self):
+        puma = rp.models.DH.Puma560()
+        q = np.array([0.2, -0.7, 0.4, 0.3, 0.5, -0.2])
+        xd = np.array([0.1, -0.2, 0.15, 0.05, -0.1, 0.2])
+        wrench = np.array([1.0, -0.5, 0.25, 0.1, -0.2, 0.3])
+
+        xdd = puma.accel_x(q, xd, wrench)
+        xdd_traj = puma.accel_x(
+            np.vstack((q, q)),
+            np.vstack((xd, xd)),
+            np.vstack((wrench, wrench)),
+        )
+
+        nt.assert_allclose(
+            xdd,
+            [-1.645157, 4.489468, -4.854711, 3.818259, 6.472284, -2.428306],
+            rtol=1e-5,
+            atol=1e-6,
+        )
+        nt.assert_allclose(xdd_traj, np.vstack((xdd, xdd)))
+
+    def test_accel_x_redundant_robot_returns_cartesian_acceleration(self):
+        panda = rp.models.DH.Panda()
+
+        xdd = panda.accel_x(panda.qr, np.zeros(6), np.zeros(6))
+
+        self.assertEqual(xdd.shape, (6,))
+        self.assertTrue(np.isfinite(xdd).all())
+
     def test_inertia(self):
         puma = rp.models.DH.Puma560()
         puma.q = puma.qn


### PR DESCRIPTION
## Summary

`DynamicsMixin.accel_x()` currently reaches its final calculation with undefined `T` and `J` variables, so the published 1.4.0 package raises `NameError` for a normal call. The same path allocates its output with `self.n` columns even though operational-space acceleration is always six-dimensional, which also prevents redundant robots from returning a valid Cartesian result.

The method already computes the analytical Jacobian `Ja` and recovers joint velocity from the requested operational-space velocity. This change therefore uses the existing `jacob0_dot()` implementation with the same angular representation and evaluates the complete kinematic relation:

```text
xdd = Jad @ qd + Ja @ qdd
```

This removes the undefined intermediate transform/Jacobian variables and the unsupported assumption that the analytical velocity transform has zero derivative. The trajectory buffer is now `(m, 6)`, independent of the number of joints. The docstring is updated to describe operational-space velocity and wrench inputs, the full acceleration equation, and the correct trajectory shapes.

Regression coverage checks three aspects:

- a non-singular Puma 560 configuration returns a fixed finite numerical result;
- a two-sample trajectory agrees with two identical single-sample evaluations;
- a seven-joint DH Panda returns a finite Cartesian vector with shape `(6,)`.

## Related issue

Closes #576

## Test plan

- `.venv/bin/python -m pytest -q tests/test_DHRobot.py -k accel_x` (`2 passed`)
- `.venv/bin/python -m pytest -q tests/test_DHRobot.py` (`72 passed, 1 skipped`)
- `.venv/bin/python -m pytest -q tests` (`723 passed, 18 skipped`)
- `.venv/bin/ruff format --check src/roboticstoolbox/robot/Dynamics.py tests/test_DHRobot.py`
- `git diff --check`

## Checklist

- [x] PR title follows Conventional Commits
- [x] Tests pass locally
- [x] Added regression tests for this change
- [x] Docstring updated
- [x] Change is focused on `accel_x()` correctness