### PR TITLE
ci: add Python 3.14 to the release wheel-build matrix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 
@@ -160,7 +161,7 @@ indent-style = "space"
 
 [tool.cibuildwheel]
 
-build = ["cp310-*", "cp311-*", "cp312-*", "cp313-*"]
+build = ["cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
 skip = ["*musllinux*"]
 
 [tool.cibuildwheel.macos]


### PR DESCRIPTION
## Summary

`ci.yml`'s test matrix already covers 3.14, but the actual released wheels (`release.yml`'s `build_wheels` job, via `pyproject.toml`'s `[tool.cibuildwheel]` build list) topped out at cp313 -- 3.14 users only had the sdist to fall back to.

Confirmed no blockers before doing this: checked a real CI run's dependency-install logs on `ubuntu-latest, Python 3.14` -- every dependency, including the ones with their own compiled extensions, already resolves to a real cp314 wheel:
- `spatialgeometry-1.4.0-cp314-cp314-linux_x86_64.whl`
- `swift_sim-2.0.0-cp314-cp314-linux_x86_64.whl`
- `coal-3.0.3-0-cp314-cp314-manylinux_2_28_x86_64.whl`

Nothing built from source anywhere in the chain. cibuildwheel 4.1.1 (already pinned for `build_wheels`) already supports `cp314-*` natively too (confirmed via its own `build-platforms.toml`).

## Test plan

- [x] `pyproject.toml` parses correctly, `cp314-*` present in the cibuildwheel build list and the 3.14 classifier added.
- [ ] Rehearsing the actual `build_wheels` job via `workflow_dispatch` on this branch to confirm a real cp314 wheel builds on all 4 platforms before merging.