### PR TITLE
test(DHRobot): port prismatic-DH flip coverage from PR #618

### DIFF
--- a/tests/test_DHRobot.py
+++ b/tests/test_DHRobot.py
@@ -168,6 +168,32 @@ class TestDHRobot(unittest.TestCase):
         nt.assert_array_almost_equal(r0.qlim, ans)
         nt.assert_array_almost_equal(r1.qlim, np.c_[qlim])
 
+    def test_A_flip_standard_dh(self):
+        # Issue #563: DHLink.A() honoured flip only when the joint ET
+        # happened to be the last ET in the sequence, which broke for any
+        # standard-DH link with a nonzero d/a/alpha. Covers both revolute
+        # and prismatic, complementing test_flip_with_nonzero_a's ETS
+        # ground-truth cross-check below with a self-consistency check
+        # (flipping the joint should equal negating q on the unflipped
+        # version). Ported from PR #618 (tahazarif10).
+        q = 0.3
+
+        flipped = rp.RevoluteDH(d=0.2, a=0.3, alpha=0.4, offset=0.1, flip=True)
+        normal = rp.RevoluteDH(d=0.2, a=0.3, alpha=0.4, offset=0.1)
+
+        nt.assert_array_almost_equal(
+            flipped.A(q).A,
+            normal.A(-q).A,
+        )
+
+        flipped = rp.PrismaticDH(theta=0.2, a=0.3, alpha=0.4, offset=0.1, flip=True)
+        normal = rp.PrismaticDH(theta=0.2, a=0.3, alpha=0.4, offset=0.1)
+
+        nt.assert_array_almost_equal(
+            flipped.A(q).A,
+            normal.A(-q).A,
+        )
+
     def test_fkine(self):
         l0 = rp.PrismaticDH()
         l1 = rp.RevoluteDH()


### PR DESCRIPTION
## Summary

#619 (merged) fixed #563 -- `DHLink.A()` honoured `flip` only when the joint ET happened to be the last ET in the sequence, which broke for any standard-DH link with a nonzero `d`/`a`/`alpha`. Its own test (`test_flip_with_nonzero_a`) covers revolute only, cross-checked against the ETS ground truth.

#618 fixed the identical bug independently, via an equivalent one-line change (`self.isflip` -- which #619's fix also uses under the hood -- vs. #618's `self.v is not None and self.v.isflip`; both reduce to the same guard), with its own test covering **both revolute and prismatic** links via a different, complementary verification style (`flipped.A(q) == normal.A(-q)` self-consistency).

Since the product fix is already in from #619, this ports #618's test coverage directly rather than merging #618 as a second (redundant) fix -- keeps the prismatic coverage and the complementary verification style without duplicating the guard.

Credit: @tahazarif10 (PR #618).

## Test plan

- [x] `test_A_flip_standard_dh` + `test_flip_with_nonzero_a` pass together.
- [x] Full `tests/test_DHRobot.py`: 74 passed, 1 skipped (pre-existing), no regressions.
