### PR TITLE
docs: fix broken PyPlot backend example in intro.rst

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -634,11 +634,12 @@ the default ``PyPlot`` backend which draws a "noodle robot" using the PyPlot bac
 
 The more general solution, and what is implemented inside ``plot`` in the example above, is::
 
-    >>> pyplot = roboticstoolbox.backends.PyPlot()
+    >>> from roboticstoolbox.backends.PyPlot import PyPlot
+    >>> pyplot = PyPlot()
     >>> pyplot.launch()
     >>> pyplot.add(puma)
     >>> puma.q = q
-    >>> puma.step()
+    >>> pyplot.step()
 
 This makes it possible to animate multiple robots in the one graphical window, or the one robot in various environments either graphical
 or real.


### PR DESCRIPTION
## Summary

Fixes #338. Fixes #487.

`docs/source/intro.rst`'s example of the low-level PyPlot backend API was broken in two ways, unchanged since at least 2022:

1. `roboticstoolbox.backends.PyPlot()` has never worked — `rtb.backends` only exposes `Connector`/`load_backend`; `PyPlot` is a submodule that needs an explicit `from roboticstoolbox.backends.PyPlot import PyPlot`.
2. `puma.step()` is wrong — `Robot` objects have no `.step()` method; it's the backend/environment (`pyplot.step()`) that steps.

Both #338 and #487 are independent user reports of following this exact doc example and hitting the first bug.

## Test plan

- [x] Verified the corrected sequence actually runs and draws real (non-degenerate) robot geometry — 2 `Line3D` objects with real joint-chain coordinates, not an empty plot.
- [x] RST parses cleanly (`docutils` parse check).