### PR TITLE
fix(pyplot): scalar plot options crash on override

### DIFF
--- a/src/roboticstoolbox/backends/PyPlot/RobotPlot.py
+++ b/src/roboticstoolbox/backends/PyPlot/RobotPlot.py
@@ -74,7 +74,15 @@ class RobotPlot:
 
         if options is not None:
             for key, value in options.items():
-                defaults[key] = {**defaults[key], **options[key]}
+                # Most options (colors, linewidths) are per-artefact dicts to
+                # merge with the default; a few (jointaxislength, eelength)
+                # are plain scalars to override outright -- **-unpacking a
+                # float raises TypeError, so only merge when both sides are
+                # dicts.
+                if isinstance(defaults.get(key), dict) and isinstance(value, dict):
+                    defaults[key] = {**defaults[key], **value}
+                else:
+                    defaults[key] = value
         self.options = defaults
 
     def draw(self):

--- a/src/roboticstoolbox/backends/PyPlot/RobotPlot2.py
+++ b/src/roboticstoolbox/backends/PyPlot/RobotPlot2.py
@@ -35,7 +35,12 @@ class RobotPlot2(RobotPlot):
 
         if options is not None:
             for key, value in options.items():
-                defaults[key] = {**defaults[key], **options[key]}
+                # See RobotPlot.__init__'s comment: eelength is a plain
+                # scalar to override outright, not a dict to merge.
+                if isinstance(defaults.get(key), dict) and isinstance(value, dict):
+                    defaults[key] = {**defaults[key], **value}
+                else:
+                    defaults[key] = value
         self.options = defaults
 
     def draw(self):

--- a/tests/test_PyPlot.py
+++ b/tests/test_PyPlot.py
@@ -69,6 +69,27 @@ class TestPyPlot(unittest.TestCase):
             env.launch(fig=fig, ax=ax)
         plt.close(fig)
 
+    def test_options_scalar_override(self):
+        # Issue #418: options={"jointaxislength": ...} (a plain scalar
+        # default, unlike the dict-valued color/linewidth options) used to
+        # crash with "'float' object is not a mapping" instead of
+        # overriding the value.
+        panda = rp.models.DH.Panda()
+        from roboticstoolbox.backends.PyPlot import PyPlot
+
+        env = PyPlot()
+        env.launch()
+        env.add(panda, options={"jointaxislength": 50, "eelength": 3})
+        robot_plot = env.robots[-1]
+        self.assertEqual(robot_plot.options["jointaxislength"], 50)
+        self.assertEqual(robot_plot.options["eelength"], 3)
+        # dict-valued options must still merge, not get replaced outright
+        env.add(panda, options={"robot": {"linewidth": 10}})
+        robot_plot2 = env.robots[-1]
+        self.assertEqual(robot_plot2.options["robot"]["linewidth"], 10)
+        self.assertIn("color", robot_plot2.options["robot"])
+        env.close()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #418.

`RobotPlot`/`RobotPlot2`'s `options=` merge logic assumed every value was a dict to merge with the matching default (true for the color/linewidth-style options), but `jointaxislength` and `eelength` are plain floats -- so `robot.plot(q, options={"jointaxislength": 50})` crashed with `TypeError: 'float' object is not a mapping` instead of overriding the value. This is the direct cause of #418 (joint-axis indicators invisible on mm-scale robots) -- the customization mechanism to fix it already existed, it just didn't work.

Fix: only merge when both the default and override are dicts; otherwise assign the override directly.

## Test plan

- [x] New regression test (`test_options_scalar_override`) covers both the scalar-override path (`jointaxislength`/`eelength`) and confirms dict-valued options (e.g. `{"robot": {"linewidth": ...}}`) still merge correctly rather than replacing the whole sub-dict.
- [x] `tests/test_PyPlot.py`, `tests/test_PyPlot2.py`: 9 passed.
- [x] `tests/test_backend_capabilities.py`, `tests/test_BaseRobot.py`: 86 passed, 7 skipped (pre-existing skips, unrelated).