### PR TITLE
fix(kinematics): fkine_all() computes wrong poses for links past a nominal end-effector

### DIFF
--- a/src/roboticstoolbox/robot/Robot.py
+++ b/src/roboticstoolbox/robot/Robot.py
@@ -705,11 +705,29 @@ class Robot(BaseRobot[Link], RobotKinematicsMixin):
         linkframes = Tbase.__class__.Alloc(self.nlinks + 1)
         linkframes[0] = Tbase
 
+        # A link's jindex may be scoped to a gripper's own separate .q state
+        # (grippers keep independent joint state -- see fkine_geometry()'s
+        # docstring) rather than this method's q parameter -- e.g. Panda's
+        # two finger joints both have jindex 0/1, coincidentally valid
+        # indices into the 7-element arm q too, but the wrong array
+        # entirely. fkine_all()'s own contract is "pose of every link
+        # frame" (see docstring) -- fulfilling that for real means sourcing
+        # each gripper joint's value from its owning gripper automatically,
+        # not leaving those slots uncomputed and pushing gripper-awareness
+        # onto every caller (plotting, geometry, ...) instead.
+        gripper_q_source = {
+            link: gripper.q
+            for gripper in self.grippers
+            for link in gripper.links
+            if link.isjoint
+        }
+
         def recurse(Tall, Tparent, q, link):
             # if joint??
             T = Tparent
             while True:
-                T *= SE3(link.A(q[link.jindex]))
+                qsrc = gripper_q_source.get(link, q)
+                T *= SE3(link.A(qsrc[link.jindex]))
 
                 Tall[link.number] = T
 
@@ -717,10 +735,17 @@ class Robot(BaseRobot[Link], RobotKinematicsMixin):
                     # no children
                     return
                 elif link.nchildren == 1:
-                    # one child
-                    if link in self.ee_links:  # pragma nocover
-                        # this link is an end-effector, go no further
-                        return
+                    # one child -- keep going regardless of whether this
+                    # link is registered in self.ee_links. A link can be the
+                    # *nominal* kinematic end-effector for fkine()'s default
+                    # target and still have real children beyond it (e.g. a
+                    # gripper's mounting link past the arm's nominal wrist/
+                    # flange link) -- stopping here left those children's
+                    # slots at the Alloc() default (identity), silently
+                    # wrong rather than computed. Confirmed via a real
+                    # Panda: panda_link8 is in ee_links, has child
+                    # panda_hand, which fkine_all() used to leave at the
+                    # origin regardless of the robot's actual pose.
                     link = link.children[0]
                     continue
                 else:
@@ -773,33 +798,8 @@ class Robot(BaseRobot[Link], RobotKinematicsMixin):
                     poses.append(linkframes[link.number] * SE3(gi._T, check=False))
 
         for gripper in self.grippers:
-            attach_link = next(
-                l for l in self.links if l.name == gripper.links[0].parent_name
-            )
-            base_T = linkframes[attach_link.number]
-
-            gripper_frames: dict[str, SE3] = {}
-
-            def recurse(Tparent, link):
-                T = Tparent
-                while True:
-                    T = T * SE3(link.A(gripper.q[link.jindex]), check=False)
-                    gripper_frames[link.name] = T
-
-                    if link.nchildren == 0:
-                        return
-                    elif link.nchildren == 1:
-                        link = link.children[0]
-                        continue
-                    else:
-                        for child in link.children:
-                            recurse(T, child)
-                        return
-
-            recurse(base_T, gripper.links[0])
-
             for link in gripper.links:
-                T_link = gripper_frames[link.name]
+                T_link = linkframes[link.number]
                 if robot_alpha > 0:
                     for gi in link.geometry:
                         poses.append(T_link * SE3(gi._T, check=False))
@@ -2140,10 +2140,11 @@ class Robot2(BaseRobot[Link2]):
                     # no children
                     return
                 elif link.nchildren == 1:
-                    # one child
-                    if link in self.ee_links:  # pragma nocover
-                        # this link is an end-effector, go no further
-                        return
+                    # one child -- see the SE3 fkine_all's identical comment
+                    # above (Robot.fkine_all): don't stop at ee_links, a
+                    # nominal end-effector can still have real children
+                    # (e.g. a mounted gripper) that fkine_all() must also
+                    # compute.
                     link = link.children[0]
                     continue
                 else:

--- a/tests/test_Robot.py
+++ b/tests/test_Robot.py
@@ -796,6 +796,92 @@ class TestRobot(unittest.TestCase):
 
         r.fkine_all(r.q)
 
+    def test_fkine_all_past_ee_link(self):
+        # fkine_all() used to stop recursing the instant it reached a
+        # link registered in self.ee_links, even when that link has real
+        # children (e.g. Panda's panda_link8 -> panda_hand -> fingers) --
+        # those children's poses were silently left at the Alloc()
+        # default (identity) rather than computed. Also checks that
+        # gripper-owned joints correctly source their value from the
+        # gripper's own separate .q, not the main arm q passed in here.
+        from spatialmath import SE3
+
+        panda = rtb.models.Panda()
+        panda.q = panda.qr
+        panda.grippers[0].q = [0.01, 0.02]
+
+        T_all = panda.fkine_all(panda.q)
+
+        hand, leftfinger, rightfinger = panda.grippers[0].links
+
+        self.assertIn("panda_link8", [l.name for l in panda.ee_links])
+
+        # panda_hand is past the nominal ee_links (panda_link8) -- must
+        # match fkine(end=...) exactly, not sit at the identity default.
+        nt.assert_allclose(
+            T_all[hand.number].A,
+            panda.fkine(panda.q, end="panda_hand").A,
+            atol=1e-9,
+        )
+
+        # finger poses must be hand's pose composed with each finger's
+        # own A(), evaluated at the gripper's own q -- not the arm's q.
+        T_hand = T_all[hand.number]
+        nt.assert_allclose(
+            T_all[leftfinger.number].A,
+            (T_hand * SE3(leftfinger.A(panda.grippers[0].q[0]))).A,
+            atol=1e-9,
+        )
+        nt.assert_allclose(
+            T_all[rightfinger.number].A,
+            (T_hand * SE3(rightfinger.A(panda.grippers[0].q[1]))).A,
+            atol=1e-9,
+        )
+
+    def test_fkine_all_gripper_q_moves_fingers(self):
+        # Changing gripper.q must actually move the finger link poses
+        # returned by fkine_all() -- individually (each finger tracks
+        # only its own jindex) and together -- and must never disturb
+        # panda_hand or the main arm chain, which don't depend on
+        # gripper.q at all.
+        panda = rtb.models.Panda()
+        panda.q = panda.qr
+
+        hand, leftfinger, rightfinger = panda.grippers[0].links
+
+        def poses():
+            T = panda.fkine_all(panda.q)
+            return T[hand.number].A.copy(), T[leftfinger.number].A.copy(), T[
+                rightfinger.number
+            ].A.copy()
+
+        panda.grippers[0].q = [0.0, 0.0]
+        hand0, left0, right0 = poses()
+
+        # move only the left finger
+        panda.grippers[0].q = [0.03, 0.0]
+        hand1, left1, right1 = poses()
+        nt.assert_allclose(hand1, hand0, atol=1e-9)
+        self.assertFalse(np.allclose(left1, left0))
+        nt.assert_allclose(right1, right0, atol=1e-9)
+
+        # move only the right finger
+        panda.grippers[0].q = [0.0, 0.03]
+        hand2, left2, right2 = poses()
+        nt.assert_allclose(hand2, hand0, atol=1e-9)
+        nt.assert_allclose(left2, left0, atol=1e-9)
+        self.assertFalse(np.allclose(right2, right0))
+
+        # move both together
+        panda.grippers[0].q = [0.03, 0.03]
+        hand3, left3, right3 = poses()
+        nt.assert_allclose(hand3, hand0, atol=1e-9)
+        self.assertFalse(np.allclose(left3, left0))
+        self.assertFalse(np.allclose(right3, right0))
+        # combined motion matches each finger's individually-moved pose
+        nt.assert_allclose(left3, left1, atol=1e-9)
+        nt.assert_allclose(right3, right2, atol=1e-9)
+
     def test_fkine_geometry_matches_scene_graph(self):
         # fkine_geometry() computes geometry-part world poses purely
         # from q (see Robot.fkine_geometry's docstring) -- this checks


### PR DESCRIPTION
## Summary

`fkine_all()`'s recursion stopped the instant it reached a link registered in `self.ee_links`, even when that link has real children — e.g. Panda's `panda_link8` (the nominal end-effector) has child `panda_hand`, itself parent to the two finger links. Those children's poses were silently left at the `Alloc()` default (identity) regardless of the robot's actual pose.

This is the real root cause of #467 ("additional line get drawn when visualizing through pyplot"): `RobotPlot.draw()` indexes `fkine_all()`'s output by `link.number` to draw the noodle plot, so `panda_hand` snapping to the origin showed up as a spurious line segment jumping back to the base — confirmed by live interactive reproduction.

## Fix

- `fkine_all()` (both SE3 and SE2 variants) no longer stops recursing at `ee_links` — it now computes a pose for every link in the tree.
- For gripper-owned joints, `fkine_all()` sources each joint's value from that gripper's own separate `.q` automatically (grippers keep independent joint state from the main arm `q`), so no caller needs gripper-awareness — matches the kinematics/rendering separation described in `desiderata.md`.
- `fkine_geometry()`'s own redundant gripper-pose recursion is removed in favour of reading `fkine_all()`'s now-correct output directly (confirmed numerically identical before/after).

## Test plan

- [x] New regression test `test_fkine_all_past_ee_link`: `fkine_all()[panda_hand.number]` matches `fkine(end='panda_hand')` exactly; finger poses match `hand_pose * finger.A(gripper.q[...])`.
- [x] New regression test `test_fkine_all_gripper_q_moves_fingers`: confirms changing `gripper.q` moves the corresponding finger pose individually and together, while never disturbing `panda_hand` or the main chain.
- [x] Both new tests confirmed to fail against the pre-fix code and pass with the fix.
- [x] Full suite green: `tests/test_Robot.py`, `test_ERobot.py`, `test_PyPlot.py`, `test_URDFRobot.py` (64 passed, 4 skipped — skips are swift-backend, unrelated).
- [x] Re-rendered the #467 repro end-to-end via PyPlot — spurious line is gone, clean single-segment noodle plot.

Fixes root cause behind #467.

🤖 Generated with [Claude Code](https://claude.com/claude-code)