### PR TITLE
fix(mobile): restore missing distance-transform diagonal

### DIFF
--- a/src/roboticstoolbox/mobile/DistanceTransformPlanner.py
+++ b/src/roboticstoolbox/mobile/DistanceTransformPlanner.py
@@ -163,7 +163,7 @@ class DistanceTransformPlanner(PlannerBase):
                 [0, -1],
                 [1, -1],
                 [-1, 0],
-                [0, 0],
+                [-1, 1],
                 [1, 0],
                 [0, 1],
                 [1, 1],

--- a/tests/test_distance_transform_plot.py
+++ b/tests/test_distance_transform_plot.py
@@ -27,6 +27,14 @@ def test_distance_transform_next_before_plan_raises():
         planner.next((0, 0))
 
 
+def test_distance_transform_next_uses_all_diagonals():
+    floorplan = np.zeros((5, 5), dtype=int)
+    planner = rtb.DistanceTransformPlanner(floorplan, metric="euclidean")
+    planner.plan((3, 1))
+
+    np.testing.assert_array_equal(planner.next((1, 3)), np.array([2, 2]))
+
+
 def test_distancexform_animate():
     # Regression test: the animate path used matplotlib.cm.get_cmap(),
     # removed in matplotlib 3.9, so plan(animate=True) raised


### PR DESCRIPTION
Thanks for contributing to RTB!

## Summary

`DistanceTransformPlanner.next()` currently has seven neighbour offsets plus `[0, 0]`, leaving the `dy=-1, dx=+1` diagonal unavailable during path extraction.

The Euclidean distance transform itself is 8-connected, so this makes path extraction asymmetric with the cost map.

This replaces the self-offset with the missing diagonal `[-1, 1]` and adds a regression test on an interior 5x5 grid where that move is the unique shortest next step.

## Related issue

Fixes #503

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`type: description`)
- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for this change, if applicable
- [x] New/changed code is type-hinted with modern syntax (`X | Y`, `list[X]`, not `Union`/`Optional`/`List`)
- [x] Docstrings updated where applicable
- [x] PR is as small/focused as practical
- [x] No test files, data files, or notebooks specific to my own project