### PR TITLE
fix(pyplot): robot.plot(..., movie=...) crashes on save

### DIFF
--- a/src/roboticstoolbox/backends/PyPlot/PyPlot.py
+++ b/src/roboticstoolbox/backends/PyPlot/PyPlot.py
@@ -512,7 +512,8 @@ class PyPlot(Connector):
 
         # render the frame and save as a PIL image in the list
         canvas = self.fig.canvas
-        return _pil("RGB", canvas.get_width_height(), canvas.tostring_rgb())
+        image = _pil("RGBA", canvas.get_width_height(), bytes(canvas.buffer_rgba()))
+        return image.convert("RGB")
 
     def _push_inline_frame(self):
         # Push a snapshot into notebook output for inline animation.

--- a/src/roboticstoolbox/robot/BaseRobot.py
+++ b/src/roboticstoolbox/robot/BaseRobot.py
@@ -2058,6 +2058,9 @@ class BaseRobot(SceneNode, DynamicsMixin, RobotPlottingMPLMixin, ABC, Generic[Li
 
         env = self._get_graphical_backend(backend)
 
+        if movie is not None:
+            from roboticstoolbox.backends.PyPlot import PyPlot
+
         launch_kwargs = {}
         for key in ("render_mode", "inline_every_n", "inline_format", "inline_dpi"):
             if key in kwargs:

--- a/tests/test_PyPlot.py
+++ b/tests/test_PyPlot.py
@@ -69,6 +69,36 @@ class TestPyPlot(unittest.TestCase):
             env.launch(fig=fig, ax=ax)
         plt.close(fig)
 
+    def test_plot_movie(self):
+        # robot.plot(..., movie=...) used to crash outright: BaseRobot.plot()
+        # referenced PyPlot in an isinstance check with no import anywhere in
+        # the module (NameError), and getframe() called the long-removed
+        # matplotlib Agg canvas method tostring_rgb() (AttributeError on
+        # modern matplotlib). Covers both bugs end-to-end via a real saved
+        # GIF, not just "no exception raised".
+        import tempfile
+        import os
+        from PIL import Image
+
+        panda = rp.models.Panda()
+        qt = rp.jtraj(panda.qr, panda.qz, 3)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "movie.gif")
+            env = panda.plot(qt.q, backend="pyplot", movie=path)
+            env.close()
+
+            self.assertTrue(os.path.exists(path))
+            img = Image.open(path)
+            n_frames = 0
+            try:
+                while True:
+                    img.seek(n_frames)
+                    n_frames += 1
+            except EOFError:
+                pass
+            self.assertEqual(n_frames, 3)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_PyPlot.py
+++ b/tests/test_PyPlot.py
@@ -89,15 +89,15 @@ class TestPyPlot(unittest.TestCase):
             env.close()
 
             self.assertTrue(os.path.exists(path))
-            img = Image.open(path)
-            n_frames = 0
-            try:
-                while True:
-                    img.seek(n_frames)
-                    n_frames += 1
-            except EOFError:
-                pass
-            self.assertEqual(n_frames, 3)
+            with Image.open(path) as img:
+                n_frames = 0
+                try:
+                    while True:
+                        img.seek(n_frames)
+                        n_frames += 1
+                except EOFError:
+                    pass
+                self.assertEqual(n_frames, 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two real, independent bugs in the movie-recording path (`robot.plot(q, backend="pyplot", movie=...)`), both found by actually reproducing #405 rather than assuming the original `w_xaxis` traceback was the whole story:

- `BaseRobot.plot()` referenced `PyPlot` in an `isinstance` check with no import of `PyPlot` anywhere in the module — an immediate `NameError` the instant `movie=` was used, on any platform, regardless of matplotlib version.
- `PyPlot.getframe()` called `canvas.tostring_rgb()`, which no longer exists on matplotlib's Agg canvas (removed after being deprecated). Replaced with the modern `canvas.buffer_rgba()`, converting the resulting RGBA image to RGB before saving (GIFs don't need the alpha channel).

## Test plan

- [x] New regression test `test_plot_movie` in `tests/test_PyPlot.py`: runs a real 3-frame trajectory through `robot.plot(..., movie=path)`, confirms the output is a valid multi-frame GIF (not just "no exception").
- [x] Confirmed the new test fails with a `NameError` against the pre-fix code, and passes with the fix.
- [x] Full `tests/test_PyPlot.py` suite green (6 passed).
- [x] Manually reproduced the original #405 report end-to-end and confirmed a real, valid 5-frame GIF is produced.

Fixes #405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)