### PR TITLE
fix(blocks): FDyn_X.output() crashed/asserted on unset xdd before deriv() ran

### DIFF
--- a/src/roboticstoolbox/blocks/arm.py
+++ b/src/roboticstoolbox/blocks/arm.py
@@ -1528,30 +1528,32 @@ class FDyn_X(ContinuousBlock):
             q0 = smb.getvector(q0, robot.n)
         # append qd0, assumed to be zero
         self._x0 = np.r_[q0, np.zeros((robot.n,))]
-        self._qdd = None
+        # Zero-acceleration placeholder for xdd until deriv() has run at
+        # least once. output() must not compute this itself: bdsim calls a
+        # continuous block's output() wherever the compute graph needs its
+        # *state*-derived ports (q, qd, x, xd here), which can happen before
+        # this block's own input is resolved -- notably here, where w
+        # (this block's input) is itself downstream of xd (this block's
+        # output) via the force-control feedback path in opspace.py. deriv()
+        # doesn't have that problem: the integrator only calls it with a
+        # genuinely resolved input. See petercorke/bdsim#81 for the general
+        # case (stateful blocks whose output() needs a resolved input).
+        self._qdd = np.zeros((robot.n,))
 
     def output(self, t, inports, x):
         n = self.robot.n
         q = x[:n]
         qd = x[n:]
-        qdd = self._qdd  # from last deriv
+        qdd = self._qdd  # cached from the last deriv() call, or the zero placeholder
 
         T = self.robot.fkine(q)
         x = smb.tr2x(T.A)
 
         Ja = self.robot.jacob0_analytical(q, self.representation)
         xd = Ja @ qd
-        # print(q)
-        # print(qd)
-        # print(xd)
-        # print(Ja)
-        # print()
 
-        if qdd is None:
-            xdd = None
-        else:
-            Ja_dot = self.robot.jacob0_dot(q, qd, J0=Ja)
-            xdd = Ja @ qdd + Ja_dot @ qd
+        Ja_dot = self.robot.jacob0_dot(q, qd, J0=Ja)
+        xdd = Ja @ qdd + Ja_dot @ qd
 
         return [q, qd, x, xd, xdd]
 


### PR DESCRIPTION
## Summary

`FDyn_X.output()` returned `xdd=None` until `self._qdd` got set as a side effect of `deriv()` running at least once. That's fine when `deriv()` always runs first, but bdsim calls a continuous block's `output()` wherever the compute graph needs its state-derived ports (`q, qd, x, xd` here) -- including during `compile()`'s dry-run connectivity check and `sim.run()`'s t=0 IC-sample pass, both *before* any `deriv()` call. Any `watch=[...]` or wiring that reads `xdd` at that point hit bdsim's `outport_value()` assertion: `AssertionError: block fdyn_x.0 output value 4 not set`.

Found via RVC3-python's `opspace.py` example (task-space operational-space control, `bd.FDYN_X(...)` with `watch=[..., robot_x.xdd]`).

Confirmed this isn't just an initialization-ordering bug fixable by caching more cleverly: `robot_x.w` (this block's own input) depends on `robot_x.xd` (this block's own output) via the force-control feedback loop in `opspace.py` (`robot_x.w = fsum + pprod`, `fprod[1] = ... * robot_x.xd`). So `w` is only resolvable *after* this same `output()` call has already returned `xd` -- `output()` genuinely can't compute `xdd` itself in one atomic call, regardless of timestamp-based staleness tracking. Filed the general case as petercorke/bdsim#81 (stateful blocks whose `output()` needs a resolved input, unlike e.g. `INTEG` which only needs its input inside `deriv()`).

## Fix

Cache a zero-acceleration placeholder for `xdd` from `__init__` instead of `None`, overwritten by every real `deriv()` call. `output()` never touches `inports`, matching every other continuous block's state-only assumption. Only the very first watched/logged `xdd` sample reads `0` instead of the true value; every step from `deriv()`'s first real call onward is exact.

## Test plan
- [x] `opspace.py` (the example that surfaced this) now runs to completion end-to-end under a real bdsim simulation -- previously crashed with the assertion above
- [x] RVC3-python's `tests/test_notebooks.py::test_notebook[chap9.ipynb]` (which runs this model via `%run -i`) now passes clean
