### PR TITLE
fix(models,ik): correct YuMi gripper parents and IK failure-path q compaction

### DIFF
--- a/src/roboticstoolbox/models/URDF/YuMi.py
+++ b/src/roboticstoolbox/models/URDF/YuMi.py
@@ -52,8 +52,8 @@ class YuMi(Robot):
         l_gripper_links = [link for link in links if link.parent == gripper_l_base]
 
         # New intermediate links
-        r_gripper = Link(name="r_gripper", parent=gripper_l_base)
-        l_gripper = Link(name="l_gripper", parent=gripper_r_base)
+        r_gripper = Link(name="r_gripper", parent=gripper_r_base)
+        l_gripper = Link(name="l_gripper", parent=gripper_l_base)
         links.append(r_gripper)
         links.append(l_gripper)
 

--- a/src/roboticstoolbox/robot/IK.py
+++ b/src/roboticstoolbox/robot/IK.py
@@ -344,7 +344,7 @@ class IKSolver(ABC):
             reason += ", solution found but violates joint limits"
 
         return IKSolution(
-            q=q,
+            q=q[ets.jindices],
             success=False,
             iterations=total_i,
             searches=self.slimit,

--- a/tests/test_BaseRobot.py
+++ b/tests/test_BaseRobot.py
@@ -492,6 +492,18 @@ class TestBaseRobot(unittest.TestCase):
 
         self.assertEqual(end.name, "r_gripper")
 
+    def test_yumi_gripper_parents(self):
+        # r_gripper/l_gripper must sit under their own arm's final link, not
+        # the other arm's -- previously swapped, so end='r_gripper' silently
+        # solved for the left arm and vice versa.
+        r = rtb.models.YuMi()
+
+        r_gripper = r._getlink("r_gripper")
+        l_gripper = r._getlink("l_gripper")
+
+        self.assertEqual(r_gripper.parent.name, "gripper_r_base")
+        self.assertEqual(l_gripper.parent.name, "gripper_l_base")
+
     def test_limits2(self):
         r = rtb.models.Panda()
 

--- a/tests/test_IK.py
+++ b/tests/test_IK.py
@@ -828,6 +828,25 @@ class TestIK(unittest.TestCase):
 
         self.assertEqual(s, ans)
 
+    def test_ik_lm_failure_returns_compact_q(self):
+        # regression: the failure-return branch of IK.py's _solve() must
+        # compact q via ets.jindices, just like the success branch does --
+        # otherwise a solver on a sub-chain whose jindex doesn't start at 0
+        # (e.g. YuMi's l_gripper, jindex 7-13) returns a zero-padded,
+        # wrong-length q on failure instead of length ets.n.
+        from spatialmath import SE3
+
+        yumi = rtb.models.YuMi()
+        ets = yumi.ets(end="l_gripper")
+
+        Tep = SE3(0.6, -0.2, 0.3) * SE3.Rx(0.2)
+
+        solver = rtb.IK_LM(ilimit=1, slimit=1)
+        sol = solver.solve(ets, Tep)
+
+        self.assertFalse(sol.success)
+        self.assertEqual(sol.q.shape[0], ets.n)
+
     def test_iter_iksol(self):
         sol = rtb.IKSolution(
             np.array([1.0, 2.0, 3.0]),


### PR DESCRIPTION
## Summary
- `YuMi.py`'s `r_gripper`/`l_gripper` links were wired to the *opposite* arm's gripper base link, so `end='r_gripper'` silently solved for the left arm and vice versa (root-cause piece of #379's "inconsistent results" report).
- While verifying the fix against the `#379` repro, found a second, independent bug: `IKSolver._solve()` (shared by `IK_LM`/`IK_NR`/`IK_GN`/`IK_QP`) compacts the returned `q` via `ets.jindices` on success but not on failure. Invisible for a sub-chain whose jindex happens to start at 0, but for one that doesn't (e.g. YuMi's `l_gripper`, jindex 7-13, only reachable once the parent-swap above is fixed) the failed solution came back at the wrong length — this is what actually crashed the `#379` repro once the swap was corrected.
- The C++ IK solvers (`IK_LM_c`/`IK_NR_c`/`IK_GN_c`) were checked and don't share this bug — they never operate in padded/global space to begin with, so there's nothing to mirror there.

Part of a larger IK-solver investigation; this is Item 1 of a 4-item plan (see `claude-notes/ik-solver-cpp-python-divergence.md`). Items 2-4 (broken `ikine_LMS` examples, `IKSolution` return-type consistency, `fkine()` compact-q support) are separate follow-up PRs.

## Test plan
- [x] New regression test: `r_gripper`/`l_gripper` resolve to the correct arm's `gripper_r_base`/`gripper_l_base` (fails on old code)
- [x] New regression test: a failed `IK_LM.solve()` on a sub-chain with non-zero-based jindex returns `q` of length `ets.n` (fails on old code)
- [x] Full test suite green (733 passed, 18 skipped) in a clean isolated venv
- [x] Manually re-ran the `#379` repro script end-to-end; the length-mismatch crash it hit is gone (a separate, already-known `fkine()` compact-q limitation remains, tracked as Item 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)