### PR TITLE
fix(examples,dhrobot): repair broken ikine_LMS/ikine_min example references

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -198,6 +198,7 @@ rst_epilog = """
    :format: html
 .. |BlockOptions| replace:: :raw-html:`<a href="https://petercorke.github.io/bdsim/internals.html?highlight=block%20__init__#bdsim.Block.__init__">common Block options</a>`
 .. |GraphicsBlockOptions| replace:: :raw-html:`<a href="https://petercorke.github.io/bdsim/internals.html?highlight=graphicsblock%20__init__#bdsim.GraphicsBlock.__init__">common GraphicsBlock options</a>`
+.. |ikargs| replace:: additional keyword arguments accepted by the underlying numerical IK solver -- ``ilimit``, ``slimit``, ``tol``, ``mask``, ``joint_limits``, ``seed``, ``k``, ``method``, ``kq``, ``km`` -- see :meth:`~roboticstoolbox.ETS.ikine_LM` for details of each
 """
 
 # -------- Suppress common noisy warnings ----------------------------------------#

--- a/examples/ikine_evaluate.py
+++ b/examples/ikine_evaluate.py
@@ -31,31 +31,25 @@ elif example == "panda":
 #  - the statement to execute for timeit
 ikfuncs = [
     (
-        robot.ikine_LM,  # Levenberg-Marquadt
+        lambda T, q0: robot.ikine_LM(T, q0=q0),  # Levenberg-Marquadt
         "ikine_LM",
-        "sol = robot.ikine_LM(T, q0)",
+        "sol = robot.ikine_LM(T, q0=q0)",
     ),
     (
-        robot.ikine_LMS,  # Levenberg-Marquadt (Sugihara)
-        "ikine_LMS",
-        "sol = robot.ikine_LMS(T, q0)",
+        lambda T, q0: robot.ikine_LM(T, q0=q0, method="sugihara", k=0.0001),
+        "ikine_LM (sugihara)",
+        "sol = robot.ikine_LM(T, q0=q0, method='sugihara', k=0.0001)",
     ),
     (
-        robot.ikine_min,  # numerical solution with no constraints
-        "ikine_min(qlim=False)",
-        "sol = robot.ikine_min(T, q0)",
+        lambda T, q0: robot.ikine_LM(T, q0=q0, joint_limits=False),
+        "ikine_LM(qlim=False)",
+        "sol = robot.ikine_LM(T, q0=q0, joint_limits=False)",
     ),
     (
-        lambda T, q0: robot.ikine_min(
-            T, q0, qlim=True
-        ),  # numerical solution with constraints
-        "ikine_min(qlim=True)",
-        "sol = robot.ikine_min(T, q0, qlim=True)",
+        lambda T, q0: robot.ikine_LM(T, q0=q0, joint_limits=True),
+        "ikine_LM(qlim=True)",
+        "sol = robot.ikine_LM(T, q0=q0, joint_limits=True)",
     ),
-    # (robot.ikine_mmc, #numerical solution with no constraints
-    #     "ikine_min(qlim=False)",
-    #     "sol = robot.ikine_min(T, q0)"
-    # ),
 ]
 if hasattr(robot, "ikine_a"):
     a = (

--- a/examples/readme.py
+++ b/examples/readme.py
@@ -11,7 +11,9 @@ print(T)
 # IK
 
 T = SE3(0.7, 0.2, 0.1) * SE3.OA([0, 1, 0], [0, 0, -1])
-sol = robot.ikine_LMS(T)  # solve IK, ignore additional outputs
+sol = robot.ikine_LM(
+    T, method="sugihara", k=0.0001
+)  # solve IK, ignore additional outputs
 print(sol.q)  # display joint angles
 # FK shows that desired end-effector pose was achieved
 print(robot.fkine(sol.q))

--- a/src/roboticstoolbox/robot/DHRobot.py
+++ b/src/roboticstoolbox/robot/DHRobot.py
@@ -2526,23 +2526,24 @@ class DHRobot(Robot):
         self,
         Tep: np.ndarray | SE3,
         q0: ArrayLike | None = None,
-        ilimit: int = 30,
-        slimit: int = 100,
-        tol: float = 1e-6,
-        joint_limits: bool = False,
-        mask: ArrayLike | None = None,
-        seed: int | None = None,
+        **ikargs,
     ):
-        return self.ets().ikine_LM(
-            Tep=Tep,
-            q0=q0,
-            ilimit=ilimit,
-            slimit=slimit,
-            tol=tol,
-            joint_limits=joint_limits,
-            mask=mask,
-            seed=seed,
-        )
+        """
+        Numerical inverse kinematics by Levenberg-Marquadt optimization
+
+        :param Tep: The desired end-effector pose
+        :param q0: The initial joint coordinate vector
+        :param ikargs: |ikargs|
+        :returns: An IKSolution containing joint coordinates ``q``, ``success`` flag, ``iterations``, ``searches``, ``residual`` error value, and ``reason`` string if applicable
+        :rtype: IKSolution
+
+        This is a thin wrapper around :meth:`ETS.ikine_LM` -- see that
+        method for the full description of the Levenberg-Marquadt solver
+        and its ``method``/``kq``/``km`` variants.
+
+        .. seealso:: :meth:`ikine_LM` (:class:`~roboticstoolbox.ETS`)
+        """
+        return self.ets().ikine_LM(Tep=Tep, q0=q0, **ikargs)
 
 
 class SerialLink(DHRobot):

--- a/tests/test_DHRobot.py
+++ b/tests/test_DHRobot.py
@@ -1029,14 +1029,18 @@ class TestDHRobot(unittest.TestCase):
         self.assertTrue(sol.success)
         self.assertAlmostEqual(np.linalg.norm(T - puma.fkine(sol.q)), 0, places=4)
 
-    # def test_ikine_LMS(self):
-    #     puma = rp.models.DH.Puma560()
+    def test_ikine_LM_ikargs_forwarding(self):
+        # DHRobot.ikine_LM forwards **ikargs straight through to
+        # ETS.ikine_LM -- confirm a non-default method/k actually reaches
+        # the underlying solver (regression: DHRobot.ikine_LM used to have
+        # its own narrow signature that silently dropped method/k/kq/km).
+        puma = rp.models.DH.Puma560()
 
-    #     T = puma.fkine(puma.qn)
+        T = puma.fkine(puma.qn)
 
-    #     sol = puma.ikine_LM(T)
-    #     self.assertTrue(sol.success)
-    #     self.assertAlmostEqual(np.linalg.norm(T - puma.fkine(sol.q)), 0, places=6)
+        sol = puma.ikine_LM(T, method="sugihara", k=0.0001, tol=1e-10, seed=0)
+        self.assertTrue(sol.success)
+        self.assertAlmostEqual(np.linalg.norm(T - puma.fkine(sol.q)), 0, places=4)
 
     # def test_ikine_unc(self):
     #     puma = rp.models.DH.Puma560()


### PR DESCRIPTION
## Summary
- `examples/readme.py` and `examples/ikine_evaluate.py` both called `robot.ikine_LMS(...)`, which hasn't existed since the LM variants were merged into `ikine_LM(method=...)`. `ikine_evaluate.py` also called the never-existent `robot.ikine_min(...)`.
- Fixed both to use `ikine_LM(method="sugihara", k=0.0001)` and `ikine_LM(joint_limits=False/True)` respectively -- `k=0.0001` matters here, the default `k=1.0` doesn't actually converge for the sugihara method (confirmed by running both scripts end-to-end).
- Also fixed a latent bug in `ikine_evaluate.py`'s timeit benchmark strings: `robot.ikine_LM(T, q0)` passes `q0` *positionally*, landing in the `end=` parameter instead of `q0=`.
- While fixing this, found that `DHRobot.ikine_LM` (a thin wrapper around `ETS.ikine_LM`) had its own narrow signature that silently dropped `method`/`k`/`kq`/`km` -- so DH robots couldn't use the wampler/sugihara variants at all. Widened it to `Tep, q0, **ikargs`, forwarding everything through, documented via a new shared `|ikargs|` Sphinx substitution (`docs/source/conf.py`, matching the existing `|BlockOptions|` pattern) so the description lives in one place as more `ikine_LM` wrappers pick it up (relevant for a follow-up PR that touches the rest of the `ikine_LM`/`ik_LM` family's docs).

Item 2 of a 4-item IK-solver cleanup plan (see `claude-notes/ik-solver-cpp-python-divergence.md`); Item 1 (YuMi gripper parent-swap fix) is PR #649.

## Test plan
- [x] New regression test: `DHRobot.ikine_LM` actually forwards `method`/`k` to the underlying solver (fails against the old narrow signature)
- [x] Full test suite green (732 passed, 18 skipped) in a clean isolated venv
- [x] Ran both example scripts end-to-end (both DH-robot branches of `ikine_evaluate.py`, and the IK-relevant portion of `readme.py`) -- no `AttributeError`, all rows converge including sugihara
- [x] Sphinx docs build (`-W --keep-going`) clean of any new warnings from the `|ikargs|` substitution or `DHRobot.ikine_LM`'s docstring

🤖 Generated with [Claude Code](https://claude.com/claude-code)