### PR TITLE
feat(examples): add ikine_XX timing columns to ik_speed.py

### DIFF
--- a/examples/ik_speed.py
+++ b/examples/ik_speed.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
-"""Benchmark the fast, C-only numerical IK solvers (ik_LM's three variants)
-over a batch of random reachable poses.
+"""Benchmark numerical IK solver speed three ways: the fast, C-only ik_XX
+solvers; the pure-Python ikine_XX solvers backed by the C-accelerated ETS
+(fkine/jacobian evaluated in C++); and ikine_XX backed by the pure-Python
+ETS fallback (fkine/jacobian evaluated in Python too, as in a pure-Python
+wheel/Pyodide build).
 """
 
 import time
@@ -10,6 +13,7 @@ import numpy as np
 from ansitable import ANSITable, Column
 
 import roboticstoolbox as rtb
+import roboticstoolbox.ets.fknm as fknm
 
 from _cpu_info import cpu_info
 
@@ -18,8 +22,14 @@ robot = rtb.models.Panda()
 ets = robot.ets()
 
 ### Experiment parameters
-# Number of problems to solve
+# Number of problems to solve for the C-accelerated columns (ik_XX and
+# ikine_XX with the C++ ETS)
 nproblems = 10_000
+
+# The pure-Python ETS fallback is interpreted at every iteration, not just
+# the outer solver loop -- 10,000 problems would take far too long, so use
+# a much smaller sample for that column alone.
+nproblems_slow = 1_000
 
 # Cartesion DoF priority matrix
 mask = np.array([1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
@@ -43,7 +53,7 @@ slimit = 100
 tol = 1e-6
 
 
-solvers = [
+ik_solvers = [
     lambda Tep: ets.ik_NR(
         Tep,
         q0=None,
@@ -101,7 +111,63 @@ solvers = [
     ),
 ]
 
-times: list[float] = []
+# ikine_XX equivalents -- same settings as above, minus pinv_damping (which
+# ikine_NR/ikine_GN don't accept; only the C-only ik_NR/ik_GN do)
+ikine_solvers = [
+    lambda Tep: ets.ikine_NR(
+        Tep,
+        q0=None,
+        ilimit=ilimit,
+        slimit=slimit,
+        tol=tol,
+        joint_limits=False,
+        mask=mask,
+        pinv=True,
+    ),
+    lambda Tep: ets.ikine_GN(
+        Tep,
+        q0=None,
+        ilimit=ilimit,
+        slimit=slimit,
+        tol=tol,
+        joint_limits=False,
+        mask=mask,
+        pinv=False,
+    ),
+    lambda Tep: ets.ikine_LM(
+        Tep,
+        q0=None,
+        ilimit=ilimit,
+        slimit=slimit,
+        tol=tol,
+        joint_limits=True,
+        mask=mask,
+        k=0.1,
+        method="chan",
+    ),
+    lambda Tep: ets.ikine_LM(
+        Tep,
+        q0=None,
+        ilimit=ilimit,
+        slimit=slimit,
+        tol=tol,
+        joint_limits=True,
+        mask=mask,
+        k=1e-4,
+        method="wampler",
+    ),
+    lambda Tep: ets.ikine_LM(
+        Tep,
+        q0=None,
+        ilimit=ilimit,
+        slimit=slimit,
+        tol=tol,
+        joint_limits=True,
+        mask=mask,
+        k=0.1,
+        method="sugihara",
+    ),
+]
 
 solver_names = [
     "Newton Raphson",
@@ -111,32 +177,70 @@ solver_names = [
     "LM Sugihara",
 ]
 
-print(f"\nNumerical Inverse Kinematics Methods benchmark:\n  * running on {cpu_info()},\n  * robot is {robot.name} with {robot.n} DoF,\n  * for a batch of {nproblems} random configurations.\n\nTime per IK solution:\n")
+print(
+    f"\nNumerical Inverse Kinematics Methods benchmark:\n"
+    f"  * running on {cpu_info()},\n"
+    f"  * robot is {robot.name} with {robot.n} DoF,\n"
+    f"  * ik_XX and ikine_XX (C++ ETS) columns use {nproblems} random configurations,\n"
+    f"  * ikine_XX (pure Python ETS) column uses {nproblems_slow} (too slow at {nproblems}).\n"
+    f"\nTime per IK solution:\n"
+)
 
-for solver in solvers:
-    print(".", file=sys.stdout, end="", flush=True) # show activity
+ik_times: list[float] = []
+ikine_cpp_times: list[float] = []
+ikine_py_times: list[float] = []
+
+for solver in ik_solvers:
+    print(".", file=sys.stdout, end="", flush=True)  # show activity
 
     start = time.time()
-
     for i in range(nproblems):
         solver(Tep[i])
+    ik_times.append(time.time() - start)
 
-    total_time = time.time() - start
-    times.append(total_time)
+for solver in ikine_solvers:
+    print(".", file=sys.stdout, end="", flush=True)
 
+    start = time.time()
+    for i in range(nproblems):
+        solver(Tep[i])
+    ikine_cpp_times.append(time.time() - start)
 
-print("\r", end="") # clear the progress line
+# Force the pure-Python ETS fallback: a fresh ETS starts with no C++ handle
+# built, and robot.ets() returns a cached instance, so dirty this one's
+# cache while _C_AVAILABLE is patched off to make it rebuild as pure-Python.
+fknm._C_AVAILABLE = False
+ets._fknm_stale = True
+
+for solver in ikine_solvers:
+    print(".", file=sys.stdout, end="", flush=True)
+
+    start = time.time()
+    for i in range(nproblems_slow):
+        solver(Tep[i])
+    ikine_py_times.append(time.time() - start)
+
+fknm._C_AVAILABLE = True
+ets._fknm_stale = True
+
+print("\r", end="")  # clear the progress line
 
 table = ANSITable(
     Column("Method", colalign="<", headalign="^"),
-    Column("Time (μs)", fmt="{:.1f}", headalign="^"),
+    Column("ik_XX (μs)", fmt="{:.1f}", headalign="^"),
+    Column("ikine_XX, C++ ETS (μs)", fmt="{:.1f}", headalign="^"),
+    Column("ikine_XX, pure Python ETS (μs)", fmt="{:.1f}", headalign="^"),
     border="thin",
 )
 
-for name, t in zip(solver_names, times):
+for name, ik_t, ikine_cpp_t, ikine_py_t in zip(
+    solver_names, ik_times, ikine_cpp_times, ikine_py_times
+):
     table.row(
         name,
-        (t / nproblems) * 1e6,
+        (ik_t / nproblems) * 1e6,
+        (ikine_cpp_t / nproblems) * 1e6,
+        (ikine_py_t / nproblems_slow) * 1e6,
     )
 
 table.print()


### PR DESCRIPTION
## Summary
Extends `examples/ik_speed.py` from a single `ik_XX`-only benchmark to three timing columns per method:

- **`ik_XX`** — the existing fast, C-only solver (unchanged)
- **`ikine_XX`, C++ ETS** — the pure-Python `ikine_XX` solver, with `fkine`/`jacob0` evaluated via the normal C++-accelerated `ETS`
- **`ikine_XX`, pure Python ETS** — the same `ikine_XX` solver, but with the `ETS` forced onto its pure-Python fallback (both the solver loop *and* every `fkine`/`jacob0` call interpreted) -- what a pure-Python wheel / Pyodide build actually experiences

The pure-Python column uses 1,000 samples instead of 10,000 -- it's orders of magnitude slower per solve (confirmed by a small dry run: LM Sugihara alone projects to ~28 minutes at 1,000 samples with this script's existing `k` values, which I left unchanged).

Forcing the pure-Python ETS path required figuring out the right lever: `robot.ets()` returns a cached/memoized instance, so a fresh `robot.ets()` call doesn't help. Instead, `roboticstoolbox.ets.fknm._C_AVAILABLE` is patched to `False` and the existing `ets`'s `_fknm_stale` flag is set, forcing its lazily-built C++ handle to rebuild as `None` on next access -- confirmed directly that `ets._fknm` becomes `None` and `ikine_LM` still works correctly against it.

## Test plan
- [x] Dry run at reduced scale (200 / 20 samples) -- all three columns populate correctly, numbers are sensible (`ik_XX` fastest, `ikine_XX`/C++ in between, `ikine_XX`/pure-Python orders of magnitude slower)
- [x] Confirmed `ets._fknm` is `None` after the patch (via direct `repr` check) and reverts cleanly afterward
- [x] `py_compile` clean
- Full 1,000-sample run not executed in this session (would take ~35-40 min) -- left for a real benchmark pass since the dry run already validates correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)